### PR TITLE
Update sirv dependency 0.4.2 -> 0.4.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3216,9 +3216,9 @@
       "dev": true
     },
     "sirv": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/sirv/-/sirv-0.4.2.tgz",
-      "integrity": "sha512-dQbZnsMaIiTQPZmbGmktz+c74zt/hyrJEB4tdp2Jj0RNv9J6B/OWR5RyrZEvIn9fyh9Zlg2OlE2XzKz6wMKGAw==",
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-0.4.6.tgz",
+      "integrity": "sha512-rYpOXlNbpHiY4nVXxuDf4mXPvKz1reZGap/LkWp9TvcZ84qD/nPBjjH/6GZsgIjVMbOslnY8YYULAyP8jMn1GQ==",
       "dev": true,
       "requires": {
         "@polka/url": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "rollup": "^2.10.5",
     "rollup-plugin-preserve-shebang": "^1.0.0",
     "sade": "^1.7.3",
-    "sirv": "^0.4.2",
+    "sirv": "^0.4.6",
     "terser": "^4.7.0",
     "tiny-glob": "^0.2.6",
     "wss": "^3.3.4"


### PR DESCRIPTION
This safeguards against a possible directory traversal attack where an attacker could request files outside of the specified directory.

See: https://github.com/lukeed/sirv/releases/tag/v0.4.6