### PR TITLE
Get next free port if requested is unavailable

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,40 @@
 import { promises as fs } from 'fs';
+import net from 'net';
 import server from './server.js';
 import bundler from './bundler.js';
+
+/**
+ * Check if the requested port is free and increase port number
+ * sequentially until we find a free port.
+ * @param {number} port The suggested port to listen on
+ * @returns {Promise<number>} The next free port
+ */
+async function getFreePort(port) {
+	let found = false;
+	let attempts = 0;
+
+	// Limit to 20 attempts for now
+	while (!found && attempts <= 20) {
+		try {
+			await new Promise((resolve, reject) => {
+				const server = net.createServer();
+				server.unref();
+				server.on('error', reject);
+				server.listen({ port }, () => {
+					port = server.address().port;
+					found = true;
+					server.close(resolve);
+				});
+			});
+		} catch (err) {
+			if (err.code !== 'EADDRINUSE') throw err;
+			port++;
+			attempts++;
+		}
+	}
+
+	return port;
+}
 
 /**
  * @typedef OtherOptions
@@ -43,7 +77,8 @@ export async function start(options = {}) {
 		}
 	});
 
-	app.listen(options.port || process.env.PORT || 8080, options.host || process.env.HOST);
+	const port = await getFreePort(options.port || process.env.PORT || 8080);
+	app.listen(port, options.host || process.env.HOST);
 	let addr = app.server.address();
 	if (typeof addr !== 'string') addr = `http://${addr.address.replace('::', 'localhost')}:${addr.port}`;
 	console.log(`Listening on ${addr}`);


### PR DESCRIPTION
This PR adds a feature that will search for the next free port if the requested one is unavailable or already in use. It will increase the port number in sequence and until we find a free port or we've reached the maximum retry attempts.

Let's say we want to run on `8080` but another process is already running, than it will try `8081` next. If that's free we're good to go.

All modern OS have a built-in feature to retrieve a random free port by requesting port `0`, but that yields numbers like `45341` which may not be as user friendly. That's arguable subjective and I'm happy to change the code to use the random OS port instead if that's preferred for wmr.

Let me know what you think :+1: 