### PR TITLE
Fix character encoding warning with demo html

### DIFF
--- a/demo/public/index.html
+++ b/demo/public/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+		<meta charset="utf-8">
 		<link rel="icon" href="data:">
     <title>Warm Module Replacement</title>
     <link rel="stylesheet" href="/style.css">
@@ -10,7 +11,7 @@
 
     <!-- a little in-page console -->
 		<!-- <script type="module" src="https://not-rawgit.glitch.me/gist/developit/60b810cbcb55e1da198a634218adcc90/raw/tiny-console.js"></script> -->
-		
+
 		<!-- test: external stylesheets don't break style HMR -->
 		<!-- <link rel="stylesheet" href="https://unpkg.com/spectre.css/dist/spectre.min.css"> -->
   </body>


### PR DESCRIPTION
Fixes the following error (only printed in Firefox):

![Screenshot from 2020-05-24 09-44-16](https://user-images.githubusercontent.com/1062408/82748560-3608d500-9da3-11ea-93b6-7840a92fb9b4.png)
