### PR TITLE
Fix duplicate "Error" prefix when logging errors

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -31,7 +31,8 @@ export async function start(options = {}) {
 					error: err.clientMessage
 				});
 			} else {
-				console.error(err + '');
+				const message = /^Error/.test(err.message) ? err.message : err + '';
+				console.error(message);
 			}
 		},
 		onBuild({ changes, duration }) {


### PR DESCRIPTION
Before:

```txt
Error: Error(htm-plugin): Unexpected token (/home/marvinh/dev/github/wmr/demo/public/header.js:101:15)
```

After:

```txt
Error(htm-plugin): Unexpected token (/home/marvinh/dev/github/wmr/demo/public/header.js:101:15)
```
