### PR TITLE
fix: use "polka/url" parser

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -1,8 +1,8 @@
-import { createServer } from 'http';
 import ws from 'ws';
 import sirv from 'sirv';
 import polka from 'polka';
 import parse from '@polka/url';
+import { createServer } from 'http';
 import compression from './lib/polkompress.js';
 
 /**


### PR DESCRIPTION
Just because it's already loaded, and is [significantly faster than native](https://github.com/lukeed/polka/tree/next/packages/url/bench#benchmarks) so why not