### PR TITLE
Fix transpiling of comments in JSX

### DIFF
--- a/src/lib/acorn-traverse.js
+++ b/src/lib/acorn-traverse.js
@@ -133,6 +133,9 @@ class Path {
 	replaceWithString(str) {
 		this.ctx.out.overwrite(this.node.start, this.node.end, str);
 	}
+	remove() {
+		this.replaceWithString('');
+	}
 	prependString(str) {
 		this.ctx.out.appendLeft(this.node.start, str);
 	}

--- a/src/plugins/transform-jsx-to-htm.js
+++ b/src/plugins/transform-jsx-to-htm.js
@@ -86,9 +86,15 @@ export default function transformJsxToHtm({ types: t, template }) {
 				path.replaceWithString(str);
 			},
 			JSXExpressionContainer(path) {
-				// path.replaceWith(path.get('expression'));
-				path.prependString('$');
+				if (t.isJSXEmptyExpression(path.get('expression'))) {
+					// <div>a{/*b*/}c</div> --> `<div>ac</div>`
+					path.remove();
+				} else {
+					// <div>{a}</div> --> `<div>${a}</div>`
+					path.prependString('$');
+				}
 			},
+			// <div>a</div> --> `<div>a</div>`
 			JSXText(path) {
 				path.replaceWithString(path.node.value);
 			}


### PR DESCRIPTION
This fixes transpiling of comments in JSX (JSXEmptyExpressions).

**Input:**

```js
<Router>
    {/* hello */}
    <Home path="/" {/*default={true}*/} />
</Router>
```

**Output:**

```js
html`<${Router}>
    
    <${Home} path="/"  />
<//>`
```

Fixes #55.