### PR TITLE
process.env inlining

### DIFF
--- a/src/bundler.js
+++ b/src/bundler.js
@@ -108,13 +108,15 @@ export function bundleDev({ cwd, out, sourcemap, aliases, onError, onBuild, prof
 			htmPlugin(),
 			wmrStylesPlugin({ hot: true, cwd }),
 			wmrPlugin(),
+			processGlobalPlugin({
+				NODE_ENV: 'development'
+			}),
 			commonjs({
 				sourceMap: sourcemap,
 				transformMixedEsModules: false,
 				extensions: ['.js', '.cjs', ''],
 				include: /^[\b]npm\//
 			}),
-			processGlobalPlugin(),
 			// unpkgPlugin()
 			json(),
 			localNpmPlugin()
@@ -207,13 +209,15 @@ export async function bundleProd({ cwd, publicDir, out, sourcemap, aliases, prof
 			htmPlugin(),
 			wmrStylesPlugin({ hot: false, cwd }),
 			wmrPlugin({ hot: false }),
+			processGlobalPlugin({
+				NODE_ENV: 'production'
+			}),
 			commonjs({
 				sourceMap: sourcemap,
 				transformMixedEsModules: false,
 				extensions: ['.js', '.cjs', ''],
 				include: /^[\b]npm\//
 			}),
-			processGlobalPlugin(),
 			json(),
 			npmPlugin({ external: false }),
 			minifyCssPlugin({ sourcemap })

--- a/src/lib/npm-middleware.js
+++ b/src/lib/npm-middleware.js
@@ -119,12 +119,14 @@ async function bundleNpmModule(mod, { source, aliases }) {
 		plugins: [
 			aliasesPlugin({ aliases }),
 			npmProviderPlugin,
+			processGlobalPlugin({
+				NODE_ENV: 'development'
+			}),
 			commonjs({
-				// TODO: extensions[]?
+				extensions: ['.js', '.cjs', ''],
 				sourceMap: false,
 				transformMixedEsModules: true
 			}),
-			processGlobalPlugin(),
 			json(),
 			{
 				name: 'never-disk',

--- a/src/plugins/process-global-plugin.js
+++ b/src/plugins/process-global-plugin.js
@@ -1,15 +1,43 @@
-export default function processGlobalPlugin() {
+/**
+ * Inject process globals and inline process.env.NODE_ENV.
+ * @param {object} [options]
+ * @param {string} [options.NODE_ENV] constant to inline for `process.env.NODE_ENV`
+ * @returns {import('rollup').Plugin}
+ */
+export default function processGlobalPlugin({ NODE_ENV = 'development' } = {}) {
+	const processObj = `{env:{NODE_ENV:${JSON.stringify(NODE_ENV)}}}`;
+
 	return {
 		name: 'process-global',
 		resolveId(id) {
 			if (id === '\0process.js') return id;
 		},
 		load(id) {
-			if (id === '\0process.js') return `export default {env:{NODE_ENV:'development'}};`;
+			if (id === '\0process.js') return `export default ${processObj};`;
 		},
 		transform(code) {
+			const orig = code;
+			// TODO: this should probably use acorn-traverse.
+			code = code.replace(
+				/([(){}&|,;=!]\s*)process\.env\.NODE_ENV\s*([!=]==?)\s*(['"])(.*?)\3/g,
+				(str, before, comparator, quote, value) => {
+					let isMatch = value == NODE_ENV;
+					if (comparator[0] == '!') isMatch = !isMatch;
+					return before + isMatch;
+				}
+			);
+
+			// if that wasn't the only way `process.env` was referenced...
 			if (code.match(/[^a-zA-Z0-9]process\.env/)) {
-				return { code: `import process from '\0process.js';${code}`, map: null };
+				// hack: avoid injecting imports into commonjs modules
+				if (code.match(/[^\w-]import[\s{]/)) {
+					code = `import process from '\0process.js';${code}`;
+				} else {
+					code = `var process=${processObj};${code}`;
+				}
+			}
+			if (code !== orig) {
+				return { code, map: null };
 			}
 		}
 	};


### PR DESCRIPTION
This adds somewhat hacky process.env inlining during development. It should probably be replaced with @marvinhagemeister's better `.env` file support (though they could maybe work together?)