### PR TITLE
Minor cli UX enhancements

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -15,7 +15,7 @@ prog
 	})
 	.command('start', 'Start a development server', { default: true })
 	.option('--port, -p', 'HTTP port to listen on (default: $PORT or 8080)')
-	.option('--host, -h', 'HTTP host to listen on (default: localhost)')
+	.option('--host', 'HTTP host to listen on (default: localhost)')
 	.option('--http2', 'Use HTTP/2 (default: false)')
 	.option('--compress', 'Enable compression (default: enabled)')
 	.option('--sourcemap', 'Enable Source Maps')


### PR DESCRIPTION
- Print common cli commands by default a179e6a
- Don't overload  `-h` for `--help` with `-h` for `--host` 5bbab92 