### PR TITLE
[experiment] Use ESBuild for both TypeScript and minification

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4043,6 +4043,12 @@
         "is-symbol": "^1.0.2"
       }
     },
+    "esbuild": {
+      "version": "0.6.14",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.6.14.tgz",
+      "integrity": "sha512-coT5T5flVNaleZQAciBJCpkJ0xB+7TShhinPLUK0Zbz/yy385DKY3nGTNmHy6+oFARI3qnNlBRAbMYgxLN9/mA==",
+      "dev": true
+    },
     "escape-goat": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/escape-goat/-/escape-goat-2.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
 		"cssnano": "^4.1.10",
 		"devcert": "^1.1.2",
 		"es-module-lexer": "^0.3.24",
+		"esbuild": "^0.6.14",
 		"eslint": "^7.4.0",
 		"eslint-config-developit": "^1.2.0",
 		"eslint-config-prettier": "^6.11.0",

--- a/src/lib/esbuild-service.js
+++ b/src/lib/esbuild-service.js
@@ -1,0 +1,59 @@
+import * as esbuild from 'esbuild';
+
+/** @type {esbuild.Service} */
+let inst,
+	svc,
+	timer,
+	usage = 0;
+
+function free() {
+	if (--usage) return;
+	clearTimeout(timer);
+	timer = setTimeout(shutdown, 10);
+}
+
+function use() {
+	clearTimeout(timer);
+	usage++;
+}
+
+export function keepalive() {
+	use();
+	free();
+}
+
+export function shutdown() {
+	if (inst) inst.stop();
+	else if (svc) svc.then(inst => usage || inst.stop());
+	inst = svc = null;
+}
+process.on('beforeExit', shutdown);
+
+/**
+ * This function is the same shape as Terser.minify, except that it is async.
+ * @param {string} code
+ * @param {esbuild.TransformOptions} opts
+ */
+export async function transform(code, opts) {
+	if (!inst) {
+		if (!svc) {
+			svc = ((esbuild && esbuild.default) || esbuild).startService();
+		}
+		inst = await svc;
+	}
+	use();
+	try {
+		const result = await inst.transform(code, opts);
+		return {
+			code: result.js,
+			map: result.jsSourceMap || null,
+			warnings: result.warnings.map(warning => warning.text)
+		};
+	} catch (err) {
+		return {
+			error: err
+		};
+	} finally {
+		free();
+	}
+}

--- a/src/lib/greenlet.js
+++ b/src/lib/greenlet.js
@@ -1,0 +1,35 @@
+import { Worker } from 'worker_threads';
+
+/**
+ * @template {(...args: any) => any} T
+ * @param {T} fn
+ * @returns {(...args: Parameters<T>) => Promise<ReturnType<T> extends Promise<infer R> ? R : ReturnType<T>>}
+ */
+export default function greenlet(fn) {
+	let n = 0,
+		t = {};
+	function a(port, fn) {
+		port.on('message', ([id, params]) => {
+			try {
+				port.postMessage([id, 0, fn(...params)]);
+			} catch (e) {
+				port.postMessage([id, 1, (e && e.stack) || e + '']);
+			}
+		});
+	}
+	function g(...args) {
+		return new Promise((s, f) => ((t[++n] = [s, f]), w.postMessage([n, args])));
+	}
+	g.terminate = () => w.terminate();
+	let w = (g.worker = new Worker(`(${a})(require("worker_threads").parentPort,${fn})`, { eval: true }));
+	w.on('message', ([id, x, result]) => (t[id] = t[id][x](result)));
+	return g;
+}
+
+/** @param {string} a @param {number} b */
+function y(a, b) {
+	return 42;
+}
+const f = greenlet(y);
+
+f();

--- a/src/plugins/fast-minify.js
+++ b/src/plugins/fast-minify.js
@@ -1,30 +1,73 @@
-import terser from 'terser';
+// import terser from 'terser';
+import { transform, keepalive } from '../lib/esbuild-service.js';
+
+/**
+ * @param {import('rollup').PluginContext} rollupContext
+ * @param {{ code?: string, map?: any, warnings?: any[], error?: any }} result
+ */
+function normalizeResult(rollupContext, result) {
+	if (result.error) rollupContext.error(result.error);
+	if (result.warnings) for (const warn of result.warnings) rollupContext.warn(warn);
+	const map = result.map && typeof result.map === 'string' ? JSON.parse(result.map) : result.map || null;
+	return { code: result.code, map };
+}
 
 /** @returns {import('rollup').Plugin} */
 export default function fastMinifyPlugin({ sourcemap = false, warnThreshold = 50, compress = false } = {}) {
 	return {
 		name: 'fast-minify',
-		renderChunk(code, chunk) {
-			const start = Date.now();
-			const out = terser.minify(code, {
-				sourceMap: sourcemap,
-				mangle: true,
-				compress,
-				module: true,
-				ecma: 9,
-				safari10: true,
-				output: {
-					comments: false
-				}
+		buildStart() {
+			keepalive();
+		},
+		async transform(code, id) {
+			if (!/\.tsx?$/.test(id)) return null;
+			const out = await transform(code, {
+				loader: 'tsx',
+				minify: false,
+				sourcefile: id,
+				sourcemap: false,
+				strict: false
 			});
+			return normalizeResult(this, out);
+		},
+		async renderChunk(code, chunk) {
+			const start = Date.now();
+
+			const out = await transform(code, {
+				define: {
+					process: 'self',
+					'process.env': 'self',
+					'process.env.NODE_ENV': '"production"'
+				},
+				minify: !!compress,
+				sourcefile: chunk.fileName,
+				sourcemap: sourcemap === true,
+				strict: false,
+				target: 'es6'
+				// target: 'es2015' // es5 not supported (yet?)
+			});
+
+			// const out = terser.minify(code, {
+			// 	sourceMap: sourcemap,
+			// 	mangle: true,
+			// 	compress: compress && {
+			// 		// passes: 2,
+			// 		...(compress === true ? {} : compress)
+			// 	},
+			// 	module: true,
+			// 	ecma: 9,
+			// 	safari10: true,
+			// 	output: {
+			// 		comments: false
+			// 	}
+			// });
+
 			const duration = Date.now() - start;
-			if (out.error) this.error(out.error);
-			if (out.warnings) for (const warn of out.warnings) this.warn(warn);
 			if (duration > warnThreshold) {
 				this.warn(`minify(${chunk.fileName}) took ${duration}ms`);
 			}
-			const map = typeof out.map === 'string' ? JSON.parse(out.map) : out.map || null;
-			return { code: out.code, map };
+
+			return normalizeResult(this, out);
 		}
 	};
 }


### PR DESCRIPTION
I decided to give ESBuild a try. It doesn't support transpiling to ES5 yet, so it's not going to work for the `foo.legacy.js` output files being generated in this PR. But it is extraordinarily fast. Production builds take under 1s on my machine and the minified sizes are pretty close to what we have with Terser.

**Pros:**
- crazy fast. I'd estimate about 5x faster prod builds.
- removes both Sucrase and Terser as deps

**Cons:**
- It's a native binary, so it can't be inlined. \*
- Installation requires a direct download from the npm registry
- The project aims to replace Rollup, not just Babel/Terser. The usage here might be too limited.

\* There's a WASM version that works in Node, but it's slower than the native version (maybe that's fine?)