### PR TITLE
(fix) Use browser field only if its a string

### DIFF
--- a/src/plugins/npm-plugin/resolve.js
+++ b/src/plugins/npm-plugin/resolve.js
@@ -58,7 +58,13 @@ export async function resolveModule(path, { readFile, hasFile, module }) {
 /** Get the best possible entry from a package.json that doesn't have an Export Map */
 function getLegacyEntry(pkg) {
 	const entry = String(
-		pkg.esmodules || pkg.modern || pkg.module || pkg['jsnext:main'] || pkg.browser || pkg.main || 'index.js'
+		pkg.esmodules ||
+			pkg.modern ||
+			pkg.module ||
+			pkg['jsnext:main'] ||
+			(typeof pkg.browser === 'string' && pkg.browser) ||
+			pkg.main ||
+			'index.js'
 	);
 	return '/' + entry.replace(/^\.?\//, '');
 }


### PR DESCRIPTION
Found this package https://unpkg.com/browse/global@4.4.0/package.json that instead of having `browser` defined as a string it's an object:
```json
"browser": {
  "min-document": false,
  "individual": false
},
```

So this PR checks if the `browser` entry is a string before assigning it. Now, I wonder if there are other cases where do we need to check this? 🤔 