### PR TITLE
Fix ReferenceError in CSS stylesheets

### DIFF
--- a/src/plugins/wmr/styles-plugin.js
+++ b/src/plugins/wmr/styles-plugin.js
@@ -152,7 +152,8 @@ export default function wmrStylesPlugin({ cwd, hot, fullPath } = {}) {
 			let code = `
 				import { style } from 'wmr';
 				style(import.meta.ROLLUP_FILE_URL_${ref}, ${JSON.stringify(idRelative)});
-				export default {${mappings.join(',')}};
+				const styles = {${mappings.join(',')}};
+				export default styles;
 				${named ? `export const ${named};` : ''}
 			`;
 


### PR DESCRIPTION
The variable "styles" was never present, but the HMR code tries to assign properties to it a few lines later.