### PR TITLE
Fix CSS-Modules HMR not working in Firefox

### DIFF
--- a/src/plugins/wmr/client.js
+++ b/src/plugins/wmr/client.js
@@ -132,7 +132,7 @@ export function style(filename, id) {
 	id = resolve(id || filename);
 	let node = styles.get(id);
 	if (node) {
-		node.href = filename;
+		node.href = filename + '?t=' + Date.now();
 	} else {
 		const node = document.createElement('link');
 		node.rel = 'stylesheet';


### PR DESCRIPTION
Firefox doesn't refresh the content of a stylesheet if the URL remains the same. We need to always append a query parameter.

Fixes #104 .