### PR TITLE
No-op more node built-ins (axios uses those)

### DIFF
--- a/src/plugins/node-builtins-plugin.js
+++ b/src/plugins/node-builtins-plugin.js
@@ -1,6 +1,10 @@
 const BUILTINS = {
 	fs: `export default {}`,
-	util: `export default {}`
+	http: `export default {}`,
+	https: `export default {}`,
+	url: `export default {}`,
+	util: `export default {}`,
+	zlib: `export default {}`
 };
 
 /**


### PR DESCRIPTION
This PR adds a few more node-specific modules, that should be a no-op. Came across those imports with `axios`.