### PR TITLE
Add support for class fields

### DIFF
--- a/demo/public/header.tsx
+++ b/demo/public/header.tsx
@@ -8,6 +8,7 @@ export default function Header() {
 				<a href="/">Home</a>
 				<a href="/about">About</a>
 				<a href="/compat">Compat</a>
+				<a href="/class-fields">Class-Fields</a>
 				<a href="/error">Error</a>
 			</nav>
 			<label>

--- a/demo/public/index.tsx
+++ b/demo/public/index.tsx
@@ -9,6 +9,7 @@ import Header from './header.tsx';
 
 const About = lazy(() => import('./pages/about/index.js'));
 const CompatPage = lazy(() => import('./pages/compat.js'));
+const ClassFields = lazy(() => import('./pages/class-fields.js'));
 
 export function App() {
 	return (
@@ -19,6 +20,7 @@ export function App() {
 					<Home path="/" />
 					<About path="/about" />
 					<CompatPage path="/compat" />
+					<ClassFields path="/class-fields" />
 					<NotFound default />
 				</Router>
 			</div>

--- a/demo/public/pages/class-fields.js
+++ b/demo/public/pages/class-fields.js
@@ -1,0 +1,20 @@
+import { Component } from 'preact';
+
+export default class ClassFields extends Component {
+	state = {
+		value: 1
+	};
+
+	onClick = () => {
+		this.setState(prev => ({ value: prev.value + 1 }));
+	};
+
+	render() {
+		return (
+			<div>
+				<p>State: {this.state.value}</p>
+				<button onClick={this.onClick}>click me</button>
+			</div>
+		);
+	}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1953,6 +1953,15 @@
       "integrity": "sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA==",
       "dev": true
     },
+    "acorn-class-fields": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/acorn-class-fields/-/acorn-class-fields-0.3.7.tgz",
+      "integrity": "sha512-jdUWSFce0fuADUljmExz4TWpPkxmRW/ZCPRqeeUzbGf0vFUcpQYbyq52l75qGd0oSwwtAepeL6hgb/naRgvcKQ==",
+      "dev": true,
+      "requires": {
+        "acorn-private-class-elements": "^0.2.7"
+      }
+    },
     "acorn-globals": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-6.0.0.tgz",
@@ -1973,6 +1982,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/acorn-jsx-walk/-/acorn-jsx-walk-2.0.0.tgz",
       "integrity": "sha512-uuo6iJj4D4ygkdzd6jPtcxs8vZgDX9YFIkqczGImoypX2fQ4dVImmu3UzA4ynixCIMTrEOWW+95M2HuBaCEOVA==",
+      "dev": true
+    },
+    "acorn-private-class-elements": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/acorn-private-class-elements/-/acorn-private-class-elements-0.2.7.tgz",
+      "integrity": "sha512-+GZH2wOKNZOBI4OOPmzpo4cs6mW297sn6fgIk1dUI08jGjhAaEwvC39mN2gJAg2lmAQJ1rBkFqKWonL3Zz6PVA==",
       "dev": true
     },
     "acorn-walk": {

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
 		"@rollup/plugin-node-resolve": "^8.1.0",
 		"@rollup/plugin-virtual": "^2.0.3",
 		"@types/jest": "^26.0.4",
+		"acorn-class-fields": "^0.3.7",
 		"acorn-jsx": "^5.2.0",
 		"acorn-jsx-walk": "^2.0.0",
 		"acorn-walk": "^7.2.0",

--- a/src/lib/rollup-plugin-container.js
+++ b/src/lib/rollup-plugin-container.js
@@ -2,6 +2,7 @@ import { resolve, relative, dirname, sep, posix } from 'path';
 import { createHash } from 'crypto';
 import { promises as fs } from 'fs';
 import * as acorn from 'acorn';
+import acornClassFields from 'acorn-class-fields';
 
 // Rollup respects "module", Node 14 doesn't.
 const cjsDefault = m => ('default' in m ? m.default : m);
@@ -151,7 +152,7 @@ export function createPluginContainer(plugins, opts = {}) {
 			}
 			if (options.acornInjectPlugins) {
 				// @ts-ignore-next
-				parser = Parser.extend(...[].concat(options.acornInjectPlugins));
+				parser = Parser.extend(...[acornClassFields].concat(options.acornInjectPlugins));
 			}
 			return options;
 		},

--- a/test/fixtures.test.js
+++ b/test/fixtures.test.js
@@ -25,6 +25,12 @@ describe('fixtures', () => {
 		expect(await getOutput(env, instance)).toMatch(`foo`);
 	});
 
+	it('should support class-fields', async () => {
+		await loadFixture('class-fields', env);
+		instance = await runWmrFast(env.tmp.path);
+		expect(await getOutput(env, instance)).toMatch(`class fields work`);
+	});
+
 	describe('empty', () => {
 		it('should print warning for missing index.html file in public dir', async () => {
 			await loadFixture('empty', env);

--- a/test/fixtures/class-fields/index.html
+++ b/test/fixtures/class-fields/index.html
@@ -1,0 +1,2 @@
+<script src="./index.js" type="module"></script>
+<pre id="out"></pre>

--- a/test/fixtures/class-fields/index.js
+++ b/test/fixtures/class-fields/index.js
@@ -1,0 +1,14 @@
+class Foo {
+	state = { value: 'class fields work' };
+	onLoad = () => {
+		return this.state;
+	};
+}
+
+const out = document.getElementById('out');
+if (!out) {
+	throw new Error("Element with id 'out' is missing in DOM");
+}
+
+const foo = new Foo();
+out.textContent = foo.onLoad().value;


### PR DESCRIPTION
Turns out it was a simple matter of adding the necessary parser enhancements to `acorn`. Browsers support it just fine 🎉 