### PR TITLE
Add support for node-resolution

### DIFF
--- a/demo/public/header.tsx
+++ b/demo/public/header.tsx
@@ -10,6 +10,7 @@ export default function Header() {
 				<a href="/compat">Compat</a>
 				<a href="/class-fields">Class-Fields</a>
 				<a href="/files">Files</a>
+				<a href="/node-resolve">Node Resolution</a>
 				<a href="/error">Error</a>
 			</nav>
 			<label>

--- a/demo/public/index.tsx
+++ b/demo/public/index.tsx
@@ -11,6 +11,7 @@ const About = lazy(() => import('./pages/about/index.js'));
 const CompatPage = lazy(() => import('./pages/compat.js'));
 const ClassFields = lazy(() => import('./pages/class-fields.js'));
 const Files = lazy(() => import('./pages/files/index.js'));
+const NodeResolve = lazy(() => import('./pages/node-resolve/index.js'));
 
 export function App() {
 	return (
@@ -23,6 +24,7 @@ export function App() {
 					<CompatPage path="/compat" />
 					<ClassFields path="/class-fields" />
 					<Files path="/files" />
+					<NodeResolve path="/node-resolve" />
 					<NotFound default />
 				</Router>
 			</div>

--- a/demo/public/pages/node-resolve/index-js/index.js
+++ b/demo/public/pages/node-resolve/index-js/index.js
@@ -1,0 +1,5 @@
+export const name = 'index.js';
+
+export default function Comp() {
+	return <span>{name}</span>;
+}

--- a/demo/public/pages/node-resolve/index-jsx/index.jsx
+++ b/demo/public/pages/node-resolve/index-jsx/index.jsx
@@ -1,0 +1,5 @@
+export const name = 'index.jsx';
+
+export default function Comp() {
+	return <span>{name}</span>;
+}

--- a/demo/public/pages/node-resolve/index-ts/index.ts
+++ b/demo/public/pages/node-resolve/index-ts/index.ts
@@ -1,0 +1,5 @@
+export const name = 'index.ts';
+
+export default function Comp() {
+	return name;
+}

--- a/demo/public/pages/node-resolve/index-tsx/index.tsx
+++ b/demo/public/pages/node-resolve/index-tsx/index.tsx
@@ -1,0 +1,5 @@
+export const name = 'index.tsx';
+
+export default function Comp() {
+	return <span>{name}</span>;
+}

--- a/demo/public/pages/node-resolve/index.js
+++ b/demo/public/pages/node-resolve/index.js
@@ -1,0 +1,66 @@
+/* eslint-disable import/extensions */
+import { name as jsName } from './js/foo';
+import { name as jsxName } from './jsx/foo';
+import { name as tsName } from './ts/foo';
+import { name as tsxName } from './tsx/foo';
+import { name as indexJsName } from './index-js';
+import { name as indexJsxName } from './index-jsx';
+import { name as indexTsName } from './index-ts';
+import { name as indexTsxName } from './index-tsx';
+import lazy from '../../lazy.js';
+
+const LazyJs = lazy(() => import('./js/foo'));
+const LazyJsx = lazy(() => import('./jsx/foo'));
+const LazyTs = lazy(() => import('./ts/foo'));
+const LazyTsx = lazy(() => import('./tsx/foo'));
+const LazyIndexJs = lazy(() => import('./index-js'));
+const LazyIndexJsx = lazy(() => import('./index-jsx'));
+const LazyIndexTs = lazy(() => import('./index-ts'));
+const LazyIndexTsx = lazy(() => import('./index-tsx'));
+
+export default function NodeResolve() {
+	return (
+		<div style="padding: 2rem;">
+			<h1>Node resolution</h1>
+			<p>Static:</p>
+			<ul>
+				<li>/js/foo -&gt; {jsName}</li>
+				<li>/jsx/foo -&gt; {jsxName}</li>
+				<li>/ts/foo -&gt; {tsName}</li>
+				<li>/tsx/foo -&gt; {tsxName}</li>
+				<li>/index-js -&gt; {indexJsName}</li>
+				<li>/index-jsx -&gt; {indexJsxName}</li>
+				<li>/index-ts -&gt; {indexTsName}</li>
+				<li>/index-tsx -&gt; {indexTsxName}</li>
+			</ul>
+
+			<p>Dynamic:</p>
+			<ul>
+				<li>
+					/js/foo -&gt; <LazyJs />
+				</li>
+				<li>
+					/jsx/foo -&gt; <LazyJsx />
+				</li>
+				<li>
+					/ts/foo -&gt; <LazyTs />
+				</li>
+				<li>
+					/tsx/foo -&gt; <LazyTsx />
+				</li>
+				<li>
+					/index-js -&gt; <LazyIndexJs />
+				</li>
+				<li>
+					/index-jsx -&gt; <LazyIndexJsx />
+				</li>
+				<li>
+					/index-ts -&gt; <LazyIndexTs />
+				</li>
+				<li>
+					/index-tsx -&gt; <LazyIndexTsx />
+				</li>
+			</ul>
+		</div>
+	);
+}

--- a/demo/public/pages/node-resolve/js/foo.js
+++ b/demo/public/pages/node-resolve/js/foo.js
@@ -1,0 +1,5 @@
+export const name = 'foo.js';
+
+export default function Comp() {
+	return <span>{name}</span>;
+}

--- a/demo/public/pages/node-resolve/jsx/foo.jsx
+++ b/demo/public/pages/node-resolve/jsx/foo.jsx
@@ -1,0 +1,5 @@
+export const name = 'foo.jsx';
+
+export default function Comp() {
+	return <span>{name}</span>;
+}

--- a/demo/public/pages/node-resolve/ts/foo.ts
+++ b/demo/public/pages/node-resolve/ts/foo.ts
@@ -1,0 +1,5 @@
+export const name = 'foo.ts';
+
+export default function Comp() {
+	return name;
+}

--- a/demo/public/pages/node-resolve/tsx/foo.tsx
+++ b/demo/public/pages/node-resolve/tsx/foo.tsx
@@ -1,0 +1,5 @@
+export const name = 'foo.tsx';
+
+export default function Comp() {
+	return <span>{name}</span>;
+}

--- a/src/plugins/resolve-extensions-plugin.js
+++ b/src/plugins/resolve-extensions-plugin.js
@@ -1,7 +1,7 @@
 import { promises as fs } from 'fs';
 import { resolve, dirname, join } from 'path';
 
-const EXTS = ['.js', '.cjs'];
+const EXTS = ['.js', '.jsx', '.cjs'];
 
 const EXTS_TS = ['.ts', '.tsx'];
 
@@ -49,59 +49,70 @@ export default function resolveExtensionsPlugin({
 		name: 'resolve-extensions-plugin',
 		async resolveId(id, importer) {
 			if (id[0] === '\0') return;
+			// Bail out on `\bnpm`
+			if (importer && importer[0] === '\b') return;
 			if (/\.(tsx?|css|s[ac]ss|wasm)$/.test(id)) return;
+			if (!/^(\.|\/)/.test(id)) return;
 
-			let resolved;
-			try {
-				resolved = await this.resolve(id, importer, { skipSelf: true });
-			} catch (e) {}
-			if (resolved) {
-				id = resolved.id;
-			} else if (importer) {
+			if (importer) {
 				id = resolve(dirname(importer), id);
 			}
 
 			const stats = await fstat(id);
-			if (stats) {
-				// If the resolved specifier is a file, use it.
-				if (stats.isFile()) {
-					return id;
-				}
+			let foundStats = false;
+			checkStats: {
+				if (stats) {
+					// If the resolved specifier is a file, use it.
+					if (stats.isFile()) {
+						return id;
+					}
 
-				// specifier resolved to a directory: look for package.json or ./index file
-				if (stats.isDirectory()) {
-					let pkgJson, pkg;
-					try {
-						pkgJson = await fs.readFile(resolve(id, 'package.json'), 'utf-8');
-					} catch (e) {}
-					if (pkgJson) {
+					// specifier resolved to a directory: look for package.json or ./index file
+					if (stats.isDirectory()) {
+						let pkgJson, pkg;
 						try {
-							pkg = JSON.parse(pkgJson);
-						} catch (e) {
-							console.warn(`Failed to parse package.json: ${id}\n  ${e}`);
-						}
-					}
-					if (pkg) {
-						const field = mainFields.find(f => pkg[f]);
-						if (field) {
-							id = join(id, pkg[field]);
-							if (/\.([mc]?js|jsx?)$/.test(id)) {
-								return id;
+							pkgJson = await fs.readFile(resolve(id, 'package.json'), 'utf-8');
+						} catch (e) {}
+						if (pkgJson) {
+							try {
+								pkg = JSON.parse(pkgJson);
+							} catch (e) {
+								console.warn(`Failed to parse package.json: ${id}\n  ${e}`);
 							}
-						} else {
-							// package.json has an implicit "main" field of `index.js`:
-							id = join(id, 'index.js');
+						}
+						if (pkg) {
+							const field = mainFields.find(f => pkg[f]);
+							if (field) {
+								id = join(id, pkg[field]);
+								if (/\.([mc]?js|jsx?)$/.test(id)) {
+									foundStats = true;
+									break checkStats;
+								}
+							} else {
+								// package.json has an implicit "main" field of `index.js`:
+								id = join(id, 'index.js');
+							}
 						}
 					}
 				}
 			}
 
-			const p = id.replace(/\.[mc]?js$/, '');
-			for (const suffix of extensions) {
-				if (await fileExists(p + suffix)) {
-					return p + suffix;
+			if (!foundStats) {
+				const p = id.replace(/\.([mc]?js|jsx)$/, '');
+				for (const suffix of extensions) {
+					if (await fileExists(p + suffix)) {
+						id = p + suffix;
+						break;
+					}
 				}
 			}
+
+			try {
+				const resolved = await this.resolve(id, importer, { skipSelf: true });
+				if (resolved) id = resolved.id;
+			} catch (e) {}
+
+			return id;
 		}
 	};
 }

--- a/src/plugins/resolve-extensions-plugin.js
+++ b/src/plugins/resolve-extensions-plugin.js
@@ -52,7 +52,7 @@ export default function resolveExtensionsPlugin({
 			// Bail out on `\bnpm`
 			if (importer && importer[0] === '\b') return;
 			if (/\.(tsx?|css|s[ac]ss|wasm)$/.test(id)) return;
-			if (!/^(\.|\/)/.test(id)) return;
+			if (!/^[./\\]/.test(id)) return;
 
 			if (importer) {
 				id = resolve(dirname(importer), id);

--- a/test/fixtures.test.js
+++ b/test/fixtures.test.js
@@ -227,4 +227,56 @@ describe('fixtures', () => {
 			expect(output).toMatch(/\/img.jpg\?asset/i);
 		});
 	});
+
+	describe('node resolution', () => {
+		it('should resolve /foo -> /foo.js', async () => {
+			await loadFixture('node-resolve-js', env);
+			instance = await runWmrFast(env.tmp.path);
+			expect(await getOutput(env, instance)).toMatch(`foo.js`);
+		});
+
+		it('should resolve /foo -> /foo.jsx', async () => {
+			await loadFixture('node-resolve-jsx', env);
+			instance = await runWmrFast(env.tmp.path);
+			expect(await getOutput(env, instance)).toMatch(`foo.jsx`);
+		});
+
+		it('should resolve /foo -> /foo.ts', async () => {
+			await loadFixture('node-resolve-ts', env);
+			instance = await runWmrFast(env.tmp.path);
+			expect(await getOutput(env, instance)).toMatch(`foo.ts`);
+		});
+
+		it('should resolve /foo -> /foo.tsx', async () => {
+			await loadFixture('node-resolve-tsx', env);
+			instance = await runWmrFast(env.tmp.path);
+			expect(await getOutput(env, instance)).toMatch(`foo.tsx`);
+		});
+
+		describe('index', () => {
+			it('should resolve /foo -> /foo/index.js', async () => {
+				await loadFixture('node-resolve-index-js', env);
+				instance = await runWmrFast(env.tmp.path);
+				expect(await getOutput(env, instance)).toMatch(`index.js`);
+			});
+
+			it('should resolve /foo -> /foo/index.jsx', async () => {
+				await loadFixture('node-resolve-index-jsx', env);
+				instance = await runWmrFast(env.tmp.path);
+				expect(await getOutput(env, instance)).toMatch(`index.jsx`);
+			});
+
+			it('should resolve /foo -> /foo/index.ts', async () => {
+				await loadFixture('node-resolve-index-ts', env);
+				instance = await runWmrFast(env.tmp.path);
+				expect(await getOutput(env, instance)).toMatch(`index.ts`);
+			});
+
+			it('should resolve /foo -> /foo/index.tsx', async () => {
+				await loadFixture('node-resolve-index-tsx', env);
+				instance = await runWmrFast(env.tmp.path);
+				expect(await getOutput(env, instance)).toMatch(`index.tsx`);
+			});
+		});
+	});
 });

--- a/test/fixtures/node-resolve-index-js/foo/index.js
+++ b/test/fixtures/node-resolve-index-js/foo/index.js
@@ -1,0 +1,1 @@
+document.getElementById('out').textContent = 'index.js';

--- a/test/fixtures/node-resolve-index-js/index.html
+++ b/test/fixtures/node-resolve-index-js/index.html
@@ -1,0 +1,2 @@
+<script src="./index.js" type="module"></script>
+<pre id="out"></pre>

--- a/test/fixtures/node-resolve-index-js/index.js
+++ b/test/fixtures/node-resolve-index-js/index.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/extensions
+import './foo';

--- a/test/fixtures/node-resolve-index-jsx/foo/index.jsx
+++ b/test/fixtures/node-resolve-index-jsx/foo/index.jsx
@@ -1,0 +1,1 @@
+document.getElementById('out').textContent = 'index.jsx';

--- a/test/fixtures/node-resolve-index-jsx/index.html
+++ b/test/fixtures/node-resolve-index-jsx/index.html
@@ -1,0 +1,2 @@
+<script src="./index.js" type="module"></script>
+<pre id="out"></pre>

--- a/test/fixtures/node-resolve-index-jsx/index.js
+++ b/test/fixtures/node-resolve-index-jsx/index.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/extensions
+import './foo';

--- a/test/fixtures/node-resolve-index-ts/foo/index.ts
+++ b/test/fixtures/node-resolve-index-ts/foo/index.ts
@@ -1,0 +1,1 @@
+document.getElementById('out').textContent = 'index.ts';

--- a/test/fixtures/node-resolve-index-ts/index.html
+++ b/test/fixtures/node-resolve-index-ts/index.html
@@ -1,0 +1,2 @@
+<script src="./index.js" type="module"></script>
+<pre id="out"></pre>

--- a/test/fixtures/node-resolve-index-ts/index.js
+++ b/test/fixtures/node-resolve-index-ts/index.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/extensions
+import './foo';

--- a/test/fixtures/node-resolve-index-tsx/foo/index.tsx
+++ b/test/fixtures/node-resolve-index-tsx/foo/index.tsx
@@ -1,0 +1,1 @@
+document.getElementById('out').textContent = 'index.tsx';

--- a/test/fixtures/node-resolve-index-tsx/index.html
+++ b/test/fixtures/node-resolve-index-tsx/index.html
@@ -1,0 +1,2 @@
+<script src="./index.js" type="module"></script>
+<pre id="out"></pre>

--- a/test/fixtures/node-resolve-index-tsx/index.js
+++ b/test/fixtures/node-resolve-index-tsx/index.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/extensions
+import './foo';

--- a/test/fixtures/node-resolve-js/foo.js
+++ b/test/fixtures/node-resolve-js/foo.js
@@ -1,0 +1,1 @@
+document.getElementById('out').textContent = 'foo.js';

--- a/test/fixtures/node-resolve-js/index.html
+++ b/test/fixtures/node-resolve-js/index.html
@@ -1,0 +1,2 @@
+<script src="./index.js" type="module"></script>
+<pre id="out"></pre>

--- a/test/fixtures/node-resolve-js/index.js
+++ b/test/fixtures/node-resolve-js/index.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/extensions
+import './foo';

--- a/test/fixtures/node-resolve-jsx/foo.jsx
+++ b/test/fixtures/node-resolve-jsx/foo.jsx
@@ -1,0 +1,1 @@
+document.getElementById('out').textContent = 'foo.jsx';

--- a/test/fixtures/node-resolve-jsx/index.html
+++ b/test/fixtures/node-resolve-jsx/index.html
@@ -1,0 +1,2 @@
+<script src="./index.js" type="module"></script>
+<pre id="out"></pre>

--- a/test/fixtures/node-resolve-jsx/index.js
+++ b/test/fixtures/node-resolve-jsx/index.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/extensions
+import './foo';

--- a/test/fixtures/node-resolve-ts/foo.ts
+++ b/test/fixtures/node-resolve-ts/foo.ts
@@ -1,0 +1,1 @@
+document.getElementById('out').textContent = 'foo.ts';

--- a/test/fixtures/node-resolve-ts/index.html
+++ b/test/fixtures/node-resolve-ts/index.html
@@ -1,0 +1,2 @@
+<script src="./index.js" type="module"></script>
+<pre id="out"></pre>

--- a/test/fixtures/node-resolve-ts/index.js
+++ b/test/fixtures/node-resolve-ts/index.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/extensions
+import './foo';

--- a/test/fixtures/node-resolve-tsx/foo.tsx
+++ b/test/fixtures/node-resolve-tsx/foo.tsx
@@ -1,0 +1,1 @@
+document.getElementById('out').textContent = 'foo.tsx';

--- a/test/fixtures/node-resolve-tsx/index.html
+++ b/test/fixtures/node-resolve-tsx/index.html
@@ -1,0 +1,2 @@
+<script src="./index.js" type="module"></script>
+<pre id="out"></pre>

--- a/test/fixtures/node-resolve-tsx/index.js
+++ b/test/fixtures/node-resolve-tsx/index.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/extensions
+import './foo';


### PR DESCRIPTION
This PR adds support for node-style resolution.

- `/foo` -> `/foo.js`
- `/foo` -> `/foo.jsx`
- `/foo` -> `/foo.ts`
- `/foo` -> `/foo.tsx`

Index resolution:

- `/foo` -> `/foo/index.js`
- `/foo` -> `/foo/index.jsx`
- `/foo` -> `/foo/index.ts`
- `/foo` -> `/foo/index.tsx`