### PR TITLE
Fix error when file doesn't match package export

### DIFF
--- a/test/fixtures/package-export/index.html
+++ b/test/fixtures/package-export/index.html
@@ -1,1 +1,0 @@
-<script src="./index.js" type="module"></script>

--- a/test/fixtures/package-export/index.js
+++ b/test/fixtures/package-export/index.js
@@ -1,4 +1,0 @@
-// eslint-disable-next-line no-unused-vars
-import urql from '@urql/core';
-
-document.getElementById('out').textContent = 'it works';


### PR DESCRIPTION
There are lots of valid reasons why a file is not listed in package.exports. The most common one is chunking for node-based apps. In `urql`'s case the main entry is listed in the export map and it imports another file which isn't listed. We threw on that file, despite having already resolved the export map.

We already had a check for that in place, but we didn't use it.

_Marking as draft: Not sure how to properly write tests for this yet_

Fixes #129 .