### PR TITLE
Simplify disk cache handling

### DIFF
--- a/src/plugins/npm-plugin/registry.js
+++ b/src/plugins/npm-plugin/registry.js
@@ -227,7 +227,7 @@ export async function loadPackageFile({ module, version, path = '' }) {
 	}
 
 	// otherwise, check if it's available in node_modules:
-	const cacheKey = `${module}@${version} :: ${path}`;
+	const cacheKey = `${module}@${version} :: \n${path}`;
 	let file = DISK_CACHE.get(cacheKey);
 	if (file != null) {
 		return file;


### PR DESCRIPTION
This PR simplifies the disk cache from being `Map<string, Map<string ,string>` to `Map<string, string>`. Makes the code shorter and requires less memory.