### PR TITLE
Fix broken JSX components with a dot

### DIFF
--- a/test/fixtures/transformations/jsx-member.expected.js
+++ b/test/fixtures/transformations/jsx-member.expected.js
@@ -1,0 +1,14 @@
+import { html } from '/@npm/htm/preact';
+const Ctx = {
+	Foo: function Foo() {
+		return html`<div />`;
+	}
+};
+
+export default function Demo() {
+	return (
+		html`<${Ctx.Foo} value=${{ foo: 123 }}>
+			<div />
+		<//>`
+	);
+}

--- a/test/fixtures/transformations/jsx-member.js
+++ b/test/fixtures/transformations/jsx-member.js
@@ -1,0 +1,13 @@
+const Ctx = {
+	Foo: function Foo() {
+		return <div />;
+	}
+};
+
+export default function Demo() {
+	return (
+		<Ctx.Foo value={{ foo: 123 }}>
+			<div />
+		</Ctx.Foo>
+	);
+}

--- a/test/transformations.test.js
+++ b/test/transformations.test.js
@@ -33,5 +33,10 @@ describe('transformations', () => {
 			const expected = await readFile(env, 'jsx.expected.js');
 			expect((await get(instance, 'jsx.js')).body).toEqual(expected);
 		});
+
+		it('should transform JSXMemberExpression', async () => {
+			const expected = await readFile(env, 'jsx-member.expected.js');
+			expect((await get(instance, 'jsx-member.js')).body).toEqual(expected);
+		});
 	});
 });


### PR DESCRIPTION
This PR fixes our custom fast JSX transform to account for member expressions being used as the tag name. Those weren't detected as a component

Before:

```jsx
html`<ctx.foo><undefined>`
```

After:

```jsx
html`<${Ctx.Foo}><//>`
```
