### PR TITLE
Support all CSS pseudo classes with arguments

### DIFF
--- a/src/lib/transform-css.js
+++ b/src/lib/transform-css.js
@@ -112,12 +112,12 @@ function processSelector(value, global = false) {
 				// `([foo="bar"`+ `]` + `[a="b" + `]` + `)`
 				if (next.startsWith('([')) {
 					let nextToken = tokens[i + 1];
-					while (nextToken === ']' || nextToken.startsWith('[') || nextToken === ')') {
+					while (nextToken && (nextToken === ']' || nextToken.startsWith('[') || nextToken === ')')) {
 						i++;
 						next += nextToken;
-						// Lookahead, but don't increase index to keep the tokenizer
-						// state correct
-						nextToken = tokens[i + 1];
+						// Lookahead, but don't increase index to keep the parser
+						// state intact
+						nextToken = i + 1 < tokens.length ? tokens[i + 1] : '';
 					}
 				}
 				out += `:${modifier}(${processSelector(next.slice(1, -1), global)})`;

--- a/test/transformations.test.js
+++ b/test/transformations.test.js
@@ -45,8 +45,12 @@ describe('transformations', () => {
 		});
 
 		it('should not cut off attribute selectors', async () => {
-			let css = `.name:not([data-type="empty"])::after { padding: 0 }`;
-			let expected = `.name_375o4j:not([data-type="empty"])::after{padding:0;}`;
+			let css = `.name:not([disabled]) { padding: 0 }`;
+			let expected = `.name_375o4j:not([disabled]){padding:0;}`;
+			expect(await modularizeCss(css, 'foo')).toEqual(expected);
+
+			css = `.name:not([data-type="empty"])::after { padding: 0 }`;
+			expected = `.name_375o4j:not([data-type="empty"])::after{padding:0;}`;
 			expect(await modularizeCss(css, 'foo')).toEqual(expected);
 
 			css = `.name:not([data-type="empty"][a^="b"])::after { padding: 0 }`;


### PR DESCRIPTION
Previously we only supported `:not()` having arguments, but there are a few more in the spec: https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes#Index_of_standard_pseudo-classes