### PR TITLE
Fix invalid JSX with escaped HTML codes

### DIFF
--- a/src/lib/transform-jsx-to-htm-lite.js
+++ b/src/lib/transform-jsx-to-htm-lite.js
@@ -126,7 +126,12 @@ export default function transformJsxToHtmLite({ types: t }, options = {}) {
 			// JSX Text is "unwrapped" to a String literal:
 			// <div>a</div> --> <div>a</div>
 			JSXText(path) {
-				path.replaceWithString(path.node.value);
+				const text = path.node.value;
+				if (/[<>&"]/.test(text)) {
+					path.replaceWithString(`\${\`${text}\`}`);
+				} else {
+					path.replaceWithString(text);
+				}
 			},
 
 			// JSX Expressions only need a "$" prefix to become tagged template expressions:

--- a/test/fixtures/transformations/jsx-escaped.expected.js
+++ b/test/fixtures/transformations/jsx-escaped.expected.js
@@ -1,0 +1,4 @@
+import { html } from '/@npm/htm/preact';
+export function Foo() {
+	return html`<span>${`<`}</span>`;
+}

--- a/test/fixtures/transformations/jsx-escaped.js
+++ b/test/fixtures/transformations/jsx-escaped.js
@@ -1,0 +1,3 @@
+export function Foo() {
+	return <span>&lt;</span>;
+}

--- a/test/transformations.test.js
+++ b/test/transformations.test.js
@@ -38,5 +38,10 @@ describe('transformations', () => {
 			const expected = await readFile(env, 'jsx-member.expected.js');
 			expect((await get(instance, 'jsx-member.js')).body).toEqual(expected);
 		});
+
+		it('should not change escaped HTML characters', async () => {
+			const expected = await readFile(env, 'jsx-escaped.expected.js');
+			expect((await get(instance, 'jsx-escaped.js')).body).toEqual(expected);
+		});
 	});
 });


### PR DESCRIPTION
We didn't account for `&lt;` and others in our custom JSX transform. This PR applies the same solution to that as the babel plugin for `htm`. See: https://github.com/developit/htm/blob/ed1c62066e4ef33c01b9269efd4e8b1a73f89887/test/babel-transform-jsx.test.mjs#L155-L160