### PR TITLE
Allow "module" environment key in export maps

### DIFF
--- a/src/plugins/npm-plugin/resolve.js
+++ b/src/plugins/npm-plugin/resolve.js
@@ -77,7 +77,7 @@ function getLegacyEntry(pkg) {
 	return '/' + entry.replace(/^\.?\//, '');
 }
 
-const ENV_KEYS = ['esmodules', 'import', 'require', 'browser', 'node', 'default'];
+const ENV_KEYS = ['esmodules', 'import', 'module', 'require', 'browser', 'node', 'default'];
 
 /** Get the best resolution for an entry from an Export Map
  * @param {Object} exp `package.exports`


### PR DESCRIPTION
Webpack is pushing folks to use it, and it aligns reasonably with our needs.