### PR TITLE
fix(create-wmr): add "wmr" as devdep

### DIFF
--- a/packages/create-wmr/tpl/package.json
+++ b/packages/create-wmr/tpl/package.json
@@ -10,5 +10,8 @@
 	"alias": {
 		"react": "preact/compat",
 		"react-dom": "preact/compat"
+	},
+	"devDependencies": {
+		"wmr": "^1.0.0"
 	}
 }

--- a/packages/create-wmr/tpl/package.json
+++ b/packages/create-wmr/tpl/package.json
@@ -11,6 +11,9 @@
 		"react": "preact/compat",
 		"react-dom": "preact/compat"
 	},
+	"dependencies": {
+		"preact-iso": "^0.2.0"
+	},
 	"devDependencies": {
 		"wmr": "^1.0.0"
 	}


### PR DESCRIPTION
Without this, the scaffolded template will only work via global `wmr` installations