### PR TITLE
fix(types): swap `declare` order for `*.module.css` files

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -41,17 +41,17 @@ declare interface NodeModule {
 }
 declare var module: NodeModule;
 
-declare module '*.css' { const url: string; export default url; }
-declare module '*.scss' { const url: string; export default url; }
-declare module '*.sass' { const url: string; export default url; }
-declare module '*.styl' { const url: string; export default url; }
-
 /** Maps authored classNames to their CSS Modules -suffixed generated classNames. */
-interface Mapping { [key: string]: string; }
+type Mapping = Record<string, string>;
 declare module '*.module.css' { const mapping: Mapping; export default mapping; }
 declare module '*.module.scss' { const mapping: Mapping; export default mapping; }
 declare module '*.module.sass' { const mapping: Mapping; export default mapping; }
 declare module '*.module.styl' { const mapping: Mapping; export default mapping; }
+
+declare module '*.css' { const url: string; export default url; }
+declare module '*.scss' { const url: string; export default url; }
+declare module '*.sass' { const url: string; export default url; }
+declare module '*.styl' { const url: string; export default url; }
 
 // Import Prefixes
 declare module 'json:';


### PR DESCRIPTION
The previous order matched `*.css` declarations for a `styles.module.css` file because it comes first in the types. This meant that all `className={ styles.home }` failed to typecheck, since `styles` was matched as a string.

This change allows `styles.modules.css` to be treated as a `Mapping` type, where as `styles.css` is treated as a `string` when imported.