### PR TITLE
Move server address log in listen callback

### DIFF
--- a/src/start.js
+++ b/src/start.js
@@ -61,7 +61,8 @@ export default async function start(options = {}) {
 	}
 
 	const app = await server(options);
-	app.listen(options.port, options.host);
-	const addresses = getServerAddresses(app.server.address(), { https: app.http2 });
-	process.stdout.write(kl.cyan(`Listening on ${addresses}`) + '\n');
+	app.listen(options.port, options.host, () => {
+		const addresses = getServerAddresses(app.server.address(), { https: app.http2 });
+		process.stdout.write(kl.cyan(`Listening on ${addresses}`) + '\n');
+	});
 }


### PR DESCRIPTION
Moves the logging for server addresses in the listen callback, since we can't always assume that the `listening` event has already been emitted when we're retrieving the addresses.

Closes #202 
