### PR TITLE
feat: add `minify` config

### DIFF
--- a/src/bundler.js
+++ b/src/bundler.js
@@ -35,6 +35,7 @@ const pathToPosix = p => p.split(sep).join(posix.sep);
  * @property {string} [publicDir = '']
  * @property {string} [out = '.cache']
  * @property {boolean} [sourcemap]
+ * @property {boolean} [minify]
  * @property {Record<string, string>} [aliases] module aliases
  * @property {boolean} [profile] Enable bundler performance profiling
  * @property {Record<string, string>} [env]
@@ -66,6 +67,7 @@ export async function bundleProd({
 	env = {},
 	plugins,
 	output,
+	minify = true,
 	npmChunks = false
 }) {
 	cwd = cwd || '';
@@ -117,7 +119,7 @@ export async function bundleProd({
 			jsonPlugin(),
 			bundlePlugin({ cwd }),
 			optimizeGraphPlugin({ publicPath: '/' }),
-			minifyCssPlugin({ sourcemap }),
+			minify && minifyCssPlugin({ sourcemap }),
 			copyAssetsPlugin({ cwd })
 		].concat(plugins || [])
 	});
@@ -136,7 +138,9 @@ export async function bundleProd({
 			return fileName;
 		},
 		hoistTransitiveImports: true,
-		plugins: [terser({ compress: true, sourcemap })],
+		plugins: [
+			minify && terser({ compress: true, sourcemap })
+		],
 		sourcemap,
 		sourcemapPathTransform(p, mapPath) {
 			let url = pathToPosix(relative(cwd, resolve(dirname(mapPath), p)));

--- a/src/bundler.js
+++ b/src/bundler.js
@@ -35,7 +35,7 @@ const pathToPosix = p => p.split(sep).join(posix.sep);
  * @property {string} [publicDir = '']
  * @property {string} [out = '.cache']
  * @property {boolean} [sourcemap]
- * @property {boolean} [minify]
+ * @property {boolean} [minify = true]
  * @property {Record<string, string>} [aliases] module aliases
  * @property {boolean} [profile] Enable bundler performance profiling
  * @property {Record<string, string>} [env]
@@ -138,9 +138,7 @@ export async function bundleProd({
 			return fileName;
 		},
 		hoistTransitiveImports: true,
-		plugins: [
-			minify && terser({ compress: true, sourcemap })
-		],
+		plugins: [minify && terser({ compress: true, sourcemap })],
 		sourcemap,
 		sourcemapPathTransform(p, mapPath) {
 			let url = pathToPosix(relative(cwd, resolve(dirname(mapPath), p)));

--- a/src/cli.js
+++ b/src/cli.js
@@ -14,7 +14,6 @@ prog
 	.option('--cwd', 'The working directory - equivalent to "(cd FOO && wmr)"')
 	.command('build', 'make a production build')
 	.option('--prerender', 'Pre-render the application to HTML')
-	.option('--minify', 'Minify built assets (default: enabled)')
 	.action(opts => {
 		opts.minify = opts.minify !== false && !/false|0/.test(opts.minify);
 		run(build(opts));

--- a/src/cli.js
+++ b/src/cli.js
@@ -14,7 +14,9 @@ prog
 	.option('--cwd', 'The working directory - equivalent to "(cd FOO && wmr)"')
 	.command('build', 'make a production build')
 	.option('--prerender', 'Pre-render the application to HTML')
+	.option('--minify', 'Minify built assets (default: enabled)')
 	.action(opts => {
+		opts.minify = opts.minify !== false && !/false|0/.test(opts.minify);
 		run(build(opts));
 	})
 	.command('serve', 'Start a production server')

--- a/src/wmr-middleware.js
+++ b/src/wmr-middleware.js
@@ -268,7 +268,6 @@ export const TRANSFORMS = {
 		res.setHeader('Content-Type', 'application/javascript;charset=utf-8');
 
 		const cacheKey = id.replace(/^[\0\b]/, '');
-
 		if (WRITE_CACHE.has(cacheKey)) return WRITE_CACHE.get(cacheKey);
 
 		const resolved = await NonRollup.resolveId(id);
@@ -290,7 +289,6 @@ export const TRANSFORMS = {
 			},
 			async resolveId(spec, importer) {
 				if (spec === 'wmr') return '/_wmr.js';
-
 				if (/^(data:|https?:|\/\/)/.test(spec)) return spec;
 
 				// const resolved = await NonRollup.resolveId(spec, importer);

--- a/types.d.ts
+++ b/types.d.ts
@@ -12,6 +12,7 @@ declare module "wmr" {
 
 	export interface Options {
 		prod: boolean;
+		minify: boolean;
 		mode: Mode;
 		cwd: string;
 		public: string;


### PR DESCRIPTION
- enabled by default (no change)
- disable via `--no-minify` or `--minify=0` or `--minify=false`
- disable via `config.minify = false`

---

May be good to have this to debug what's going on w/ production. (Not everyone can follow Terser output 😉)
Am roughly doing this to debug what's going on with #213 

***TODO***

* Rename this to `--compress`?
    _Would be common term between commands, but `build`'s meaning would be different._

* Hide this from the CLI help text?
    _Could still attach it to CLI, but not advertise it in `wmr build -h` output._

* Do we even want this?
    _Didn't discuss this with anyone, sorry~!_