### PR TITLE
chore: replace `tiny-glob` with `totalist` for inputs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12825,9 +12825,9 @@
       }
     },
     "totalist": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/totalist/-/totalist-2.0.0.tgz",
-      "integrity": "sha512-+Y17F0YzxfACxTyjfhnJQEe7afPA0GSpYlFkl2VFMxYP7jshQf9gXV7cH47EfToBumFThfKBvfAcoUn6fdNeRQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-1.1.0.tgz",
+      "integrity": "sha512-gduQwd1rOdDMGxFG1gEvhV88Oirdo2p+KjoYFU7k2g+i7n6AFFbDQ5kMPUsW0pNbfQsB/cwXvT1i4Bue0s9g5g==",
       "dev": true
     },
     "touch": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5316,18 +5316,6 @@
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "dev": true
     },
-    "globalyzer": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/globalyzer/-/globalyzer-0.1.4.tgz",
-      "integrity": "sha512-LeguVWaxgHN0MNbWC6YljNMzHkrCny9fzjmEUdnF1kQ7wATFD1RHFRqA1qxaX2tgxGENlcxjOflopBwj3YZiXA==",
-      "dev": true
-    },
-    "globrex": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
-      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
-      "dev": true
-    },
     "got": {
       "version": "9.6.0",
       "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
@@ -11909,6 +11897,12 @@
           "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.11.tgz",
           "integrity": "sha512-3NsZsJIA/22P3QUyrEDNA2D133H4j224twJrdipXN38dpnIOzAbUDtOwkcJ5pXmn75w7LSQDjA4tO9dm1XlqlA==",
           "dev": true
+        },
+        "totalist": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/totalist/-/totalist-1.1.0.tgz",
+          "integrity": "sha512-gduQwd1rOdDMGxFG1gEvhV88Oirdo2p+KjoYFU7k2g+i7n6AFFbDQ5kMPUsW0pNbfQsB/cwXvT1i4Bue0s9g5g==",
+          "dev": true
         }
       }
     },
@@ -12742,16 +12736,6 @@
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
       "dev": true
     },
-    "tiny-glob": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.6.tgz",
-      "integrity": "sha512-A7ewMqPu1B5PWwC3m7KVgAu96Ch5LA0w4SnEN/LbDREj/gAD0nPWboRbn8YoP9ISZXqeNAlMvKSKoEuhcfK3Pw==",
-      "dev": true,
-      "requires": {
-        "globalyzer": "^0.1.0",
-        "globrex": "^0.1.1"
-      }
-    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -12841,9 +12825,9 @@
       }
     },
     "totalist": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/totalist/-/totalist-1.1.0.tgz",
-      "integrity": "sha512-gduQwd1rOdDMGxFG1gEvhV88Oirdo2p+KjoYFU7k2g+i7n6AFFbDQ5kMPUsW0pNbfQsB/cwXvT1i4Bue0s9g5g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-2.0.0.tgz",
+      "integrity": "sha512-+Y17F0YzxfACxTyjfhnJQEe7afPA0GSpYlFkl2VFMxYP7jshQf9gXV7cH47EfToBumFThfKBvfAcoUn6fdNeRQ==",
       "dev": true
     },
     "touch": {

--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
 		"tar-stream": "^2.1.3",
 		"terser": "^4.8.0",
 		"tmp-promise": "^3.0.2",
-		"totalist": "^2.0.0",
+		"totalist": "^1.1.0",
 		"utf-8-validate": "^5.0.2",
 		"ws": "^7.3.1"
 	},

--- a/package.json
+++ b/package.json
@@ -144,8 +144,8 @@
 		"sucrase": "^3.15.0",
 		"tar-stream": "^2.1.3",
 		"terser": "^4.8.0",
-		"tiny-glob": "^0.2.6",
 		"tmp-promise": "^3.0.2",
+		"totalist": "^2.0.0",
 		"utf-8-validate": "^5.0.2",
 		"ws": "^7.3.1"
 	},

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -133,8 +133,7 @@ const config = {
 		}),
 		nodeResolve({
 			preferBuiltins: true,
-			extensions: ['.mjs', '.js', '.json', '.es6', '.node'],
-			dedupe: ['totalist/sync']
+			extensions: ['.mjs', '.js', '.json', '.es6', '.node']
 		}),
 		json()
 	]

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -133,7 +133,8 @@ const config = {
 		}),
 		nodeResolve({
 			preferBuiltins: true,
-			extensions: ['.mjs', '.js', '.json', '.es6', '.node']
+			extensions: ['.mjs', '.js', '.json', '.es6', '.node'],
+			dedupe: ['totalist/sync']
 		}),
 		json()
 	]

--- a/src/bundler.js
+++ b/src/bundler.js
@@ -10,7 +10,7 @@ import npmPlugin from './plugins/npm-plugin/index.js';
 import publicPathPlugin from './plugins/public-path-plugin.js';
 import minifyCssPlugin from './plugins/minify-css-plugin.js';
 import htmlEntriesPlugin from './plugins/html-entries-plugin.js';
-import { totalist } from 'totalist';
+import totalist from 'totalist';
 import aliasesPlugin from './plugins/aliases-plugin.js';
 import processGlobalPlugin from './plugins/process-global-plugin.js';
 import urlPlugin from './plugins/url-plugin.js';

--- a/src/bundler.js
+++ b/src/bundler.js
@@ -10,7 +10,7 @@ import npmPlugin from './plugins/npm-plugin/index.js';
 import publicPathPlugin from './plugins/public-path-plugin.js';
 import minifyCssPlugin from './plugins/minify-css-plugin.js';
 import htmlEntriesPlugin from './plugins/html-entries-plugin.js';
-import glob from 'tiny-glob';
+import { totalist } from 'totalist';
 import aliasesPlugin from './plugins/aliases-plugin.js';
 import processGlobalPlugin from './plugins/process-global-plugin.js';
 import urlPlugin from './plugins/url-plugin.js';
@@ -71,15 +71,15 @@ export async function bundleProd({
 	cwd = cwd || '';
 	root = root || cwd;
 
-	const htmlFiles = await glob('**/*.html', {
-		cwd,
-		absolute: true,
-		filesOnly: true
-	});
-
 	// note: we intentionally pass these to Rollup as posix paths
 	const ignore = /^\.\/(node_modules|dist|build)\//;
-	const input = htmlFiles.map(p => './' + pathToPosix(relative('.', p))).filter(p => !ignore.test(p));
+	/** @type {string[]} */const input = [];
+
+	await totalist(cwd, (rel, abs) => {
+		if (ignore.test(abs)) return;
+		if (!/\.html?/.test(rel)) return;
+		input.push('./' + pathToPosix(relative('.', abs)));
+	});
 
 	const bundle = await rollup.rollup({
 		input,

--- a/src/bundler.js
+++ b/src/bundler.js
@@ -10,7 +10,7 @@ import npmPlugin from './plugins/npm-plugin/index.js';
 import publicPathPlugin from './plugins/public-path-plugin.js';
 import minifyCssPlugin from './plugins/minify-css-plugin.js';
 import htmlEntriesPlugin from './plugins/html-entries-plugin.js';
-import totalist from 'totalist/sync/index.mjs'; // TODO: temporary
+import totalist from 'totalist';
 import aliasesPlugin from './plugins/aliases-plugin.js';
 import processGlobalPlugin from './plugins/process-global-plugin.js';
 import urlPlugin from './plugins/url-plugin.js';
@@ -75,7 +75,7 @@ export async function bundleProd({
 	const ignore = /^\.\/(node_modules|dist|build)\//;
 	/** @type {string[]} */ const input = [];
 
-	totalist(cwd, (rel, abs) => {
+	await totalist(cwd, (rel, abs) => {
 		if (ignore.test(abs)) return;
 		if (!/\.html?/.test(rel)) return;
 		input.push('./' + pathToPosix(relative(root, abs)));

--- a/src/bundler.js
+++ b/src/bundler.js
@@ -10,7 +10,7 @@ import npmPlugin from './plugins/npm-plugin/index.js';
 import publicPathPlugin from './plugins/public-path-plugin.js';
 import minifyCssPlugin from './plugins/minify-css-plugin.js';
 import htmlEntriesPlugin from './plugins/html-entries-plugin.js';
-import totalist from 'totalist';
+import totalist from 'totalist/sync';
 import aliasesPlugin from './plugins/aliases-plugin.js';
 import processGlobalPlugin from './plugins/process-global-plugin.js';
 import urlPlugin from './plugins/url-plugin.js';
@@ -75,7 +75,7 @@ export async function bundleProd({
 	const ignore = /^\.\/(node_modules|dist|build)\//;
 	/** @type {string[]} */ const input = [];
 
-	await totalist(cwd, (rel, abs) => {
+	totalist(cwd, (rel, abs) => {
 		if (ignore.test(abs)) return;
 		if (!/\.html?/.test(rel)) return;
 		input.push('./' + pathToPosix(relative(root, abs)));

--- a/src/bundler.js
+++ b/src/bundler.js
@@ -10,7 +10,7 @@ import npmPlugin from './plugins/npm-plugin/index.js';
 import publicPathPlugin from './plugins/public-path-plugin.js';
 import minifyCssPlugin from './plugins/minify-css-plugin.js';
 import htmlEntriesPlugin from './plugins/html-entries-plugin.js';
-import totalist from 'totalist/sync';
+import totalist from 'totalist/sync/index.mjs'; // TODO: temporary
 import aliasesPlugin from './plugins/aliases-plugin.js';
 import processGlobalPlugin from './plugins/process-global-plugin.js';
 import urlPlugin from './plugins/url-plugin.js';

--- a/src/bundler.js
+++ b/src/bundler.js
@@ -73,7 +73,7 @@ export async function bundleProd({
 
 	// note: we intentionally pass these to Rollup as posix paths
 	const ignore = /^\.\/(node_modules|dist|build)\//;
-	/** @type {string[]} */const input = [];
+	/** @type {string[]} */ const input = [];
 
 	await totalist(cwd, (rel, abs) => {
 		if (ignore.test(abs)) return;

--- a/src/bundler.js
+++ b/src/bundler.js
@@ -78,7 +78,7 @@ export async function bundleProd({
 	await totalist(cwd, (rel, abs) => {
 		if (ignore.test(abs)) return;
 		if (!/\.html?/.test(rel)) return;
-		input.push('./' + pathToPosix(relative('.', abs)));
+		input.push('./' + pathToPosix(relative(root, abs)));
 	});
 
 	const bundle = await rollup.rollup({


### PR DESCRIPTION
There was only `tiny-glob` usage inside `bundler.js` to collect HTML input files (updated) and inside `watch-plugin.js`, which was unused.

No need to bring in the `tiny-glob` dependency chain when just crawling for a single extension.

(~1.5kb => 200b gzip)