### PR TITLE
make small poc for bubbling and keeping track of a module-graph

### DIFF
--- a/demo/public/index.tsx
+++ b/demo/public/index.tsx
@@ -7,7 +7,6 @@ import NotFound from './pages/_404.js';
 import Header from './header.tsx';
 // import './style.css';
 import { useCounter } from './useCustomHook.js'
-
 const About = lazy(() => import('./pages/about/index.js'));
 const CompatPage = lazy(() => import('./pages/compat.js'));
 const ClassFields = lazy(() => import('./pages/class-fields.js'));

--- a/demo/public/index.tsx
+++ b/demo/public/index.tsx
@@ -6,7 +6,7 @@ import Home from './pages/home.js';
 import NotFound from './pages/_404.js';
 import Header from './header.tsx';
 // import './style.css';
-import { useCounter } from './useCustomHook'
+import { useCounter } from './useCustomHook.js'
 
 const About = lazy(() => import('./pages/about/index.js'));
 const CompatPage = lazy(() => import('./pages/compat.js'));
@@ -15,10 +15,12 @@ const Files = lazy(() => import('./pages/files/index.js'));
 const Environment = lazy(async () => (await import('./pages/environment/index.js')).Environment);
 
 export function App() {
-	useCounter();
+	const [count, increment] = useCounter();
 	return (
 		<Loc>
 			<div class="app">
+				{count}
+				<button onClick={increment}>Click me</button>
 				<Header />
 				<ErrorBoundary>
 					<Router>

--- a/demo/public/index.tsx
+++ b/demo/public/index.tsx
@@ -6,6 +6,7 @@ import Home from './pages/home.js';
 import NotFound from './pages/_404.js';
 import Header from './header.tsx';
 // import './style.css';
+import { useCounter } from './useCustomHook'
 
 const About = lazy(() => import('./pages/about/index.js'));
 const CompatPage = lazy(() => import('./pages/compat.js'));
@@ -14,6 +15,7 @@ const Files = lazy(() => import('./pages/files/index.js'));
 const Environment = lazy(async () => (await import('./pages/environment/index.js')).Environment);
 
 export function App() {
+	useCounter();
 	return (
 		<Loc>
 			<div class="app">

--- a/demo/public/useCustomHook.js
+++ b/demo/public/useCustomHook.js
@@ -1,0 +1,6 @@
+import { useState } from 'preact/hooks';
+
+export function useCounter() {
+	const [state, setState] = useState(0);
+	return [state, setState(state + 1)];
+}

--- a/demo/public/useCustomHook.js
+++ b/demo/public/useCustomHook.js
@@ -1,6 +1,6 @@
 import { useState } from 'preact/hooks';
 
 export function useCounter() {
-	const [state, setState] = useState(2);
-	return [state, () => setState(state + 2)];
+	const [state, setState] = useState(1);
+	return [state, () => setState(state + 1)];
 }

--- a/demo/public/useCustomHook.js
+++ b/demo/public/useCustomHook.js
@@ -1,6 +1,6 @@
 import { useState } from 'preact/hooks';
 
 export function useCounter() {
-	const [state, setState] = useState(0);
-	return [state, setState(state + 1)];
+	const [state, setState] = useState(2);
+	return [state, () => setState(state + 2)];
 }

--- a/src/plugins/wmr/client.js
+++ b/src/plugins/wmr/client.js
@@ -95,8 +95,8 @@ function update(url, visited = new Set()) {
 	const p = mod.import ? mod.import(newUrl) : import(newUrl);
 
 	if (!accept.length) {
-		const dependents = Array.from(mod.dependents);
-		if (dependents.length) {
+		const { dependents } = mod;
+		if (dependents.size) {
 			for (const dependent of dependents) {
 				if (!visited.has(dependent)) {
 					visited.add(dependent);

--- a/src/plugins/wmr/client.js
+++ b/src/plugins/wmr/client.js
@@ -22,6 +22,7 @@ const URL_SUFFIX = /\/(index\.html)?$/;
 
 function handleMessage(e) {
 	const data = JSON.parse(e.data);
+
 	switch (data.type) {
 		case 'update':
 			data.changes.forEach(url => {
@@ -112,8 +113,6 @@ function update(url, visited = new Set()) {
 		.then(m => {
 			accept.forEach(c => (c({ module: m }), mod.accept.delete(c)));
 			dispose.forEach(c => (c(), mod.dispose.delete(c)));
-			// accept.forEach(c => c({ module: m }));
-			// dispose.forEach(c => c());
 		})
 		.catch(err => {
 			console.error(err);
@@ -132,11 +131,10 @@ function getMod(url) {
 // HMR API
 export function createHotContext(url, dependencies) {
 	const mod = getMod(url);
-
 	if (dependencies) {
 		for (const dep of dependencies) {
-			mod.dependencies.add(dep);
-			const dependentMod = getMod(dep);
+			mod.dependencies.add(resolve(dep));
+			const dependentMod = getMod(resolve(dep));
 			dependentMod.dependents.add(url);
 		}
 	}

--- a/src/plugins/wmr/plugin.js
+++ b/src/plugins/wmr/plugin.js
@@ -39,7 +39,7 @@ export function getWmrClient({ hot = true } = {}) {
  * @param {object} options
  * @returns {import('rollup').Plugin}
  */
-export default function wmrPlugin({ hot = true } = {}) {
+export default function wmrPlugin({ hot = true, cwd } = {}) {
 	if (BYPASS_HMR) hot = false;
 
 	return {

--- a/src/plugins/wmr/plugin.js
+++ b/src/plugins/wmr/plugin.js
@@ -1,6 +1,5 @@
 import { promises as fs } from 'fs';
 import MagicString from 'magic-string';
-import { ESM_KEYWORDS } from '../fast-cjs-plugin.js';
 import { parse } from 'es-module-lexer/dist/lexer.js';
 import { ESM_KEYWORDS } from '../fast-cjs-plugin.js';
 
@@ -62,8 +61,6 @@ export default function wmrPlugin({ hot = true, cwd } = {}) {
 			let hasHot = /(import\.meta\.hot|\$IMPORT_META_HOT\$)/.test(code);
 			let before = '';
 			let after = '';
-
-			const hasEsmKeywords = ESM_KEYWORDS.test(code);
 
 			// stub webpack-style `module.hot` using `import.meta.hot`:
 			if (code.match(/module\.hot/)) {

--- a/src/plugins/wmr/plugin.js
+++ b/src/plugins/wmr/plugin.js
@@ -2,6 +2,7 @@ import { promises as fs } from 'fs';
 import MagicString from 'magic-string';
 import { ESM_KEYWORDS } from '../fast-cjs-plugin.js';
 import { parse } from 'es-module-lexer/dist/lexer.js';
+import { ESM_KEYWORDS } from '../fast-cjs-plugin.js';
 
 const BYPASS_HMR = process.env.BYPASS_HMR === 'true';
 
@@ -61,6 +62,8 @@ export default function wmrPlugin({ hot = true } = {}) {
 			let hasHot = /(import\.meta\.hot|\$IMPORT_META_HOT\$)/.test(code);
 			let before = '';
 			let after = '';
+
+			const hasEsmKeywords = ESM_KEYWORDS.test(code);
 
 			// stub webpack-style `module.hot` using `import.meta.hot`:
 			if (code.match(/module\.hot/)) {

--- a/src/plugins/wmr/plugin.js
+++ b/src/plugins/wmr/plugin.js
@@ -54,7 +54,7 @@ export default function wmrPlugin({ hot = true } = {}) {
 			}
 			return null;
 		},
-		transform(code, id) {
+		async transform(code, id) {
 			const ch = id[0];
 			if (ch === '\0' || ch === '\b' || !/\.[tj]sx?$/.test(id)) return;
 			let hasHot = /(import\.meta\.hot|\$IMPORT_META_HOT\$)/.test(code);

--- a/src/wmr-middleware.js
+++ b/src/wmr-middleware.js
@@ -264,11 +264,18 @@ export const TRANSFORMS = {
 	},
 
 	// Handle individual JavaScript modules
-	async js({ id, file, prefix, res, cwd, out, NonRollup }) {
+	async js({ id, file, prefix, res, cwd, out, NonRollup, req }) {
 		res.setHeader('Content-Type', 'application/javascript;charset=utf-8');
 
 		const cacheKey = id.replace(/^[\0\b]/, '');
-		if (WRITE_CACHE.has(cacheKey)) return WRITE_CACHE.get(cacheKey);
+
+		if (WRITE_CACHE.has(cacheKey)) {
+			if (req.query.t) {
+				WRITE_CACHE.delete(cacheKey);
+			} else {
+				return WRITE_CACHE.get(cacheKey);
+			}
+		}
 
 		const resolved = await NonRollup.resolveId(id);
 		const resolvedId = typeof resolved == 'object' ? resolved && resolved.id : resolved;


### PR DESCRIPTION
Current unknown mainly is whether or not when we are bubbling up if we'll also get updated child-modules.

Parent (with accept callback)
Child (whithout) 

When the child gets an update, we bubble up to Parent. When Parent handles this will the browser have a new version of Child or will we have to rewrite the import in Parent (recursively)?

Current tests seem to indicate that it works