### PR TITLE
feat: Adding support for yarn in create-wmr

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ Create a new project in seconds using [create-wmr](https://npm.im/create-wmr):
 
 <strong><code>npm init wmr your-project-name</code></strong>
 
+or
+
+<strong><code>yarn create wmr your-project-name</code></strong>
+
 <p>
 <img width="400" src="https://user-images.githubusercontent.com/105127/100917537-4661e100-34a5-11eb-89bd-565b7bc31919.gif">
 </p>

--- a/packages/create-wmr/src/index.js
+++ b/packages/create-wmr/src/index.js
@@ -11,7 +11,6 @@ const { dim, bold, cyan, red } = kleur;
 
 sade('create-wmr [dir]', true)
 	.option('--eslint', 'Set up the Preact ESLint configuration (takes a lot longer)', false)
-	.option('--yarn', 'Set up WMR using Yarn instead of NPM as the package manager', false)
 	.describe('Initialize a WMR project')
 	.example('npm init wmr ./some-directory')
 	.action(async (dir, opts) => {
@@ -33,7 +32,7 @@ sade('create-wmr [dir]', true)
 			color: 'yellow',
 			text: 'installing WMR...'
 		}).start();
-		const packageManager = opts.yarn ? 'yarn' : 'npm';
+		const packageManager = /yarn/.test(process.env.npm_execpath) ? 'yarn' : 'npm';
 		// @ts-ignore-next
 		await getPackageManager({ prefer: packageManager }).catch(() => {
 			process.stderr.write(`\n${red(`${packageManager} cannot be found`)}\n`);


### PR DESCRIPTION
Adds support for initializing WMR project with Yarn.

Also now properly catches in the chance the chosen package manager is not installed/accessible. 