### PR TITLE
fix: Adding jsxFactory to create-wmr's tsconfig file

### DIFF
--- a/packages/create-wmr/tpl/tsconfig.json
+++ b/packages/create-wmr/tpl/tsconfig.json
@@ -2,6 +2,7 @@
 	"compileOnSave": false,
 	"compilerOptions": {
 		"jsx": "preserve",
+		"jsxFactory": "preact.h",
 		"allowJs": true,
 		"checkJs": true,
 		// "strict": true,

--- a/packages/create-wmr/tpl/tsconfig.json
+++ b/packages/create-wmr/tpl/tsconfig.json
@@ -3,6 +3,7 @@
 	"compilerOptions": {
 		"jsx": "preserve",
 		"jsxFactory": "preact.h",
+		"jsxFragmentFactory": "preact.Fragment",
 		"allowJs": true,
 		"checkJs": true,
 		// "strict": true,


### PR DESCRIPTION
Enabling `noImplicitAny` or `strict` in a new WMR app with `.tsx` files will present the following error at every usage of JSX: 

```
TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
```

While this won't hinder the app from being built in any way, it is quite distracting in an IDE. This should stop that error from popping up.