### PR TITLE
feat: Adding types for preact-iso

### DIFF
--- a/packages/preact-iso/hydrate.d.ts
+++ b/packages/preact-iso/hydrate.d.ts
@@ -1,0 +1,3 @@
+import { VNode } from 'preact';
+
+export default function hydrate(jsx: VNode, parent?: VNode): void;

--- a/packages/preact-iso/hydrate.d.ts
+++ b/packages/preact-iso/hydrate.d.ts
@@ -1,3 +1,3 @@
-import { VNode } from 'preact';
+import { ComponentChild, VNode } from 'preact';
 
-export default function hydrate(jsx: VNode, parent?: VNode): void;
+export default function hydrate(jsx: ComponentChild, parent?: VNode): void;

--- a/packages/preact-iso/index.d.ts
+++ b/packages/preact-iso/index.d.ts
@@ -1,0 +1,4 @@
+import { VNode } from 'preact';
+import { PrerenderOptions } from './prerender';
+
+export default function prerender(vnode: VNode, options?: PrerenderOptions): { html: string, links: Set<string>};

--- a/packages/preact-iso/lazy.d.ts
+++ b/packages/preact-iso/lazy.d.ts
@@ -1,5 +1,5 @@
-import { VNode } from 'preact';
+import { ComponentChildren, VNode } from 'preact';
 
 export default function lazy<T>(load: () => Promise<{ default: T }>): T;
 
-export function ErrorBoundary(props: { children?: VNode }): VNode;
+export function ErrorBoundary(props: { children?: ComponentChildren }): VNode;

--- a/packages/preact-iso/lazy.d.ts
+++ b/packages/preact-iso/lazy.d.ts
@@ -1,4 +1,4 @@
-import { FunctionalComponent, VNode } from 'preact';
+import { VNode } from 'preact';
 
 export default function lazy<T>(load: () => Promise<{ default: T }>): T;
 

--- a/packages/preact-iso/lazy.d.ts
+++ b/packages/preact-iso/lazy.d.ts
@@ -1,0 +1,5 @@
+import { FunctionalComponent, VNode } from 'preact';
+
+export default function lazy<T>(load: () => Promise<{ default: T }>): T;
+
+export function ErrorBoundary(props: { children?: VNode }): VNode;

--- a/packages/preact-iso/package.json
+++ b/packages/preact-iso/package.json
@@ -4,6 +4,7 @@
   "description": "Isomorphic utilities for Preact",
   "main": "./index.js",
   "module": "./index.js",
+  "types": "./index.d.ts",
   "exports": {
     ".": "./index.js",
     "./router": "./router.js",

--- a/packages/preact-iso/prerender.d.ts
+++ b/packages/preact-iso/prerender.d.ts
@@ -1,0 +1,8 @@
+import { VNode } from 'preact';
+
+export interface PrerenderOptions {
+	maxDepth?: number,
+	props?: Record<string, unknown>
+}
+
+export default function prerender(vnode: VNode, options?: PrerenderOptions): Promise<{ html: string, links: Set<string>}>;

--- a/packages/preact-iso/router.d.ts
+++ b/packages/preact-iso/router.d.ts
@@ -12,5 +12,7 @@ interface RoutableProps {
 }
 
 declare module 'preact' {
-	export interface Attributes extends RoutableProps {}
+	namespace JSX {
+		interface IntrinsicAttributes extends RoutableProps {}
+	}
 }

--- a/packages/preact-iso/router.d.ts
+++ b/packages/preact-iso/router.d.ts
@@ -1,10 +1,10 @@
-import { VNode } from 'preact';
+import { FunctionComponent, VNode } from 'preact';
 
-export function LocationProvider(props: { children?: VNode }): VNode;
+export const LocationProvider: FunctionComponent;
 
 export function Router(props: { onLoadEnd?: () => void, onLoadStart?: () => void, children?: VNode[] }): VNode;
 
-export const useLoc: () => { url: string, path: string, query: Object, route };
+export const useLoc: () => { url: string, path: string, query: Record<string, string>, route };
 
 interface RoutableProps {
 	path?: string;

--- a/packages/preact-iso/router.d.ts
+++ b/packages/preact-iso/router.d.ts
@@ -15,4 +15,5 @@ declare module 'preact' {
 	namespace JSX {
 		interface IntrinsicAttributes extends RoutableProps {}
 	}
+	interface Attributes extends RoutableProps {}
 }

--- a/packages/preact-iso/router.d.ts
+++ b/packages/preact-iso/router.d.ts
@@ -4,7 +4,7 @@ export const LocationProvider: FunctionComponent;
 
 export function Router(props: { onLoadEnd?: () => void, onLoadStart?: () => void, children?: VNode[] }): VNode;
 
-export const useLoc: () => { url: string, path: string, query: Record<string, string>, route };
+export const useLoc: () => { url: string, path: string, query: Record<string, string>, route: (url: string) => void };
 
 interface RoutableProps {
 	path?: string;

--- a/packages/preact-iso/router.d.ts
+++ b/packages/preact-iso/router.d.ts
@@ -1,0 +1,16 @@
+import { VNode } from 'preact';
+
+export function LocationProvider(props: { children?: VNode }): VNode;
+
+export function Router(props: { onLoadEnd?: () => void, onLoadStart?: () => void, children?: VNode[] }): VNode;
+
+export const useLoc: () => { url: string, path: string, query: Object, route };
+
+interface RoutableProps {
+	path?: string;
+	default?: boolean;
+}
+
+declare module 'preact' {
+	export interface Attributes extends RoutableProps {}
+}


### PR DESCRIPTION
Adds types to `preact-iso` package. Closes #243 .

Let me know if anything looks incorrect. I've tested locally in a WMR app with the `tsconfig` having `strict` enabled and everything seemed to work correctly.