### PR TITLE
Hoist JSX namespace to be global by default

### DIFF
--- a/src/plugins/node-builtins-plugin.js
+++ b/src/plugins/node-builtins-plugin.js
@@ -21,7 +21,7 @@ export default function nodeBuiltinsPlugin({ production } = {}) {
 				}
 				this.warn(
 					`Warning: ${id} is a Node built-in - WMR does not polyfill these.\n` +
-					`For development the module has been stubbed.`
+						`For development the module has been stubbed.`
 				);
 				return {
 					code: 'export default {}',

--- a/test/fixtures.test.js
+++ b/test/fixtures.test.js
@@ -397,9 +397,9 @@ describe('fixtures', () => {
 		});
 
 		it('should return an warning if a node built-in is used in development', async () => {
-			const warning = `
-				Warning: http is a Node built-in - WMR does not polyfill these. 
-				For development the module has been stubbed.`;
+			const warning =
+				`Warning: http is a Node built-in - WMR does not polyfill these.\n` +
+				`For development the module has been stubbed.`;
 			const warns = [];
 			await rollup({
 				input: 'test/fixtures/node-builtins/http.js',

--- a/types.d.ts
+++ b/types.d.ts
@@ -79,3 +79,23 @@ declare module '*.woff2' { const url: string; export default url; }
 declare module '*.eot' { const url: string; export default url; }
 declare module '*.ttf' { const url: string; export default url; }
 declare module '*.otf' { const url: string; export default url; }
+
+// Make Preact's JSX the global JSX
+declare namespace JSX {
+	// @ts-ignore
+	interface IntrinsicElements extends preact.JSX.IntrinsicElements {}
+	// @ts-ignore
+	interface IntrinsicAttributes extends preact.JSX.IntrinsicAttributes {}
+	// @ts-ignore
+	interface Element extends preact.JSX.Element {}
+	// @ts-ignore
+	interface ElementClass extends preact.JSX.ElementClass {}
+	interface ElementAttributesProperty extends preact.JSX.ElementAttributesProperty {}
+	interface ElementChildrenAttribute extends preact.JSX.ElementChildrenAttribute {}
+	interface CSSProperties extends preact.JSX.CSSProperties {}
+	interface SVGAttributes extends preact.JSX.SVGAttributes {}
+	interface PathAttributes extends preact.JSX.PathAttributes {}
+	interface TargetedEvent extends preact.JSX.TargetedEvent {}
+	interface DOMAttributes<Target extends EventTarget> extends preact.JSX.DOMAttributes<Target> {}
+	interface HTMLAttributes<RefType extends EventTarget = EventTarget> extends preact.JSX.HTMLAttributes<RefType> {}
+}


### PR DESCRIPTION
This essentially does what #245 did but for folks who aren't using `create-wmr`.

Fixes #258.