### PR TITLE
Fix typo (was missing a `'`)

### DIFF
--- a/packages/@wmr-plugins_nomodule/README.md
+++ b/packages/@wmr-plugins_nomodule/README.md
@@ -10,7 +10,7 @@ New browsers get the new stuff, old browsers get the old stuff.
 Add this to your `wmr.config.js`:
 
 ```js
-import nomodule from '@wmr-plugins/nomodule;
+import nomodule from '@wmr-plugins/nomodule';
 
 export function build(config) {
   nomodule(config);


### PR DESCRIPTION
Very easy fix, it's fine if one of the contributor make this fix themselves directly but just wanted to make someone aware of the spelling mistake.

Thank for the great work you are all doing. This project is very exciting.