### PR TITLE
Fix Instructions (need a .mjs config if not won't work)

### DIFF
--- a/packages/@wmr-plugins_nomodule/README.md
+++ b/packages/@wmr-plugins_nomodule/README.md
@@ -7,7 +7,7 @@ New browsers get the new stuff, old browsers get the old stuff.
 
 ## Usage
 
-Add this to your `wmr.config.js`:
+Add this to your `wmr.config.mjs`:
 
 ```js
 import nomodule from '@wmr-plugins/nomodule';


### PR DESCRIPTION
If the file ends with `.js` instead you will be faced with the following error in node 14.

```
wmr build --prerender
(node:60792) Warning: To load an ES module, set "type": "module" in the package.json or use the .mjs extension.
```

And the nomodule plugin won't be used.

I was looking at what was inside the `dist` folder output and I couldn't see the legacy output without changing the config file extension to `.mjs`)