### PR TITLE
create-wmr: Limiting template's tsconfig's scope to "public/"

### DIFF
--- a/packages/create-wmr/tpl/tsconfig.json
+++ b/packages/create-wmr/tpl/tsconfig.json
@@ -15,6 +15,7 @@
 		"allowSyntheticDefaultImports": true,
 		"downlevelIteration": true
 	},
+	"include": ["public"],
 	"typeAcquisition": {
 		"enable": true
 	}


### PR DESCRIPTION
When there's no `include` flag for the TSConfig it will default to covering all files with supported extensions. As `allowJS` is enabled, this includes JS.

The issue with this comes from enabling `strict`/`noImplicitAny`. Top level config files (like `wmr.config.js`) will now start to throw errors because of missing types. While you can write JSDoc to silence this, it is a bit unnecessary.

The better default would likely be to limit the TSConfig's scope to just the `public/` dir. Top-level configs or other files should likely be excluded.