### PR TITLE
preact-iso: Adding "useLocation" alias for "useLoc"

### DIFF
--- a/packages/preact-iso/router.d.ts
+++ b/packages/preact-iso/router.d.ts
@@ -4,7 +4,7 @@ export const LocationProvider: FunctionComponent;
 
 export function Router(props: { onLoadEnd?: () => void, onLoadStart?: () => void, children?: VNode[] }): VNode;
 
-type LocationHook =	() => { url: string, path: string, query: Record<string, string>, route: (url: string) => void };
+type LocationHook = () => { url: string, path: string, query: Record<string, string>, route: (url: string) => void };
 export const useLoc: LocationHook;
 export const useLocation: LocationHook;
 

--- a/packages/preact-iso/router.d.ts
+++ b/packages/preact-iso/router.d.ts
@@ -4,9 +4,9 @@ export const LocationProvider: FunctionComponent;
 
 export function Router(props: { onLoadEnd?: () => void, onLoadStart?: () => void, children?: VNode[] }): VNode;
 
-type LocationHook = () => { url: string, path: string, query: Record<string, string>, route: (url: string) => void };
-export const useLoc: LocationHook;
-export const useLocation: LocationHook;
+type LocationHook = { url: string, path: string, query: Record<string, string>, route: (url: string) => void };
+export const useLoc: () => LocationHook;
+export const useLocation: () => LocationHook;
 
 interface RoutableProps {
 	path?: string;

--- a/packages/preact-iso/router.d.ts
+++ b/packages/preact-iso/router.d.ts
@@ -4,7 +4,9 @@ export const LocationProvider: FunctionComponent;
 
 export function Router(props: { onLoadEnd?: () => void, onLoadStart?: () => void, children?: VNode[] }): VNode;
 
-export const useLoc: () => { url: string, path: string, query: Record<string, string>, route: (url: string) => void };
+type LocationHook =	() => { url: string, path: string, query: Record<string, string>, route: (url: string) => void };
+export const useLoc: LocationHook;
+export const useLocation: LocationHook;
 
 interface RoutableProps {
 	path?: string;

--- a/packages/preact-iso/router.js
+++ b/packages/preact-iso/router.js
@@ -98,3 +98,4 @@ Router.Provider = LocationProvider;
 LocationProvider.ctx = createContext(/** @type {{ url: string, path: string, query: object, route }} */ ({}));
 
 export const useLoc = () => useContext(LocationProvider.ctx);
+export const useLocation = useLoc;


### PR DESCRIPTION
Addresses & closes #269 

Adds a simple alias `useLocation()` for `useLoc()`. React-router, Reach, and Wouter all use `useLocation()` so I imagine this is more comfortable for a pretty large group of people.