### PR TITLE
docs: Adding preact/compat note to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,17 @@ render(<App />, document.body);
 }
 ```
 
+`preact/compat` is our compatibility layer that allows you to leverage the many libraries of the React ecosystem and use them with Preact. If this is something you'd like to use with WMR you can add an `alias` section as well to your `package.json`:
+
+```json
+{
+	"alias": {
+		"react": "preact/compat",
+		"react-dom": "preact/compat"
+	}
+}
+```
+
 **5.** You're all set! As an extra step, if you'd like WMR to prerender your application to static HTML during production builds, replace `render()` with [preact-iso](https://www.npmjs.com/package/preact-iso):
 
 ```diff


### PR DESCRIPTION
Created in regards to #282. For those that set up WMR manually a note about the alias that comes with the template could be helpful.

Let me know if the verbiage should be altered or anything. The first sentence is swiped from the Preact site. 