### PR TITLE
Variable dynamic import prod

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1540,6 +1540,32 @@
 				}
 			}
 		},
+		"@nodelib/fs.scandir": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz",
+			"integrity": "sha512-33g3pMJk3bg5nXbL/+CY6I2eJDzZAni49PfJnL5fghPTggPvBd/pFNSgJsdAgWptuFu7qq/ERvOYFlhvsLTCKA==",
+			"dev": true,
+			"requires": {
+				"@nodelib/fs.stat": "2.0.4",
+				"run-parallel": "^1.1.9"
+			}
+		},
+		"@nodelib/fs.stat": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.4.tgz",
+			"integrity": "sha512-IYlHJA0clt2+Vg7bccq+TzRdJvv19c2INqBSsoOLp1je7xjtr7J26+WXR72MCdvU9q1qTzIWDfhMf+DRvQJK4Q==",
+			"dev": true
+		},
+		"@nodelib/fs.walk": {
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.6.tgz",
+			"integrity": "sha512-8Broas6vTtW4GIXTAHDoE32hnN2M5ykgCpWGbuXHQ15vEMqr23pB76e/GZcYsZCHALv50ktd24qhEyKr6wBtow==",
+			"dev": true,
+			"requires": {
+				"@nodelib/fs.scandir": "2.1.4",
+				"fastq": "^1.6.0"
+			}
+		},
 		"@polka/url": {
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/@polka/url/-/url-0.5.0.tgz",
@@ -1568,6 +1594,45 @@
 				"is-reference": "^1.1.2",
 				"magic-string": "^0.25.2",
 				"resolve": "^1.11.0"
+			}
+		},
+		"@rollup/plugin-dynamic-import-vars": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-dynamic-import-vars/-/plugin-dynamic-import-vars-1.1.1.tgz",
+			"integrity": "sha512-PqdfEKlsyPx0hPSSuOigCHgrQbOLW+y09KRRCFeWiBBnkuh4LlV6mfrDefmLQijj8XCWzyLct2rK+q89qvRp7A==",
+			"dev": true,
+			"requires": {
+				"@rollup/pluginutils": "^3.1.0",
+				"estree-walker": "^2.0.1",
+				"globby": "^11.0.1",
+				"magic-string": "^0.25.7"
+			},
+			"dependencies": {
+				"@rollup/pluginutils": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+					"integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+					"dev": true,
+					"requires": {
+						"@types/estree": "0.0.39",
+						"estree-walker": "^1.0.1",
+						"picomatch": "^2.2.2"
+					},
+					"dependencies": {
+						"estree-walker": {
+							"version": "1.0.1",
+							"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+							"integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+							"dev": true
+						}
+					}
+				},
+				"estree-walker": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+					"integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+					"dev": true
+				}
 			}
 		},
 		"@rollup/plugin-json": {
@@ -2164,6 +2229,12 @@
 				"es-abstract": "^1.17.0",
 				"is-string": "^1.0.5"
 			}
+		},
+		"array-union": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+			"dev": true
 		},
 		"array-unique": {
 			"version": "0.3.2",
@@ -3924,6 +3995,15 @@
 			"integrity": "sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg==",
 			"dev": true
 		},
+		"dir-glob": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+			"integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+			"dev": true,
+			"requires": {
+				"path-type": "^4.0.0"
+			}
+		},
 		"doctrine": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -4921,6 +5001,20 @@
 			"integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
 			"dev": true
 		},
+		"fast-glob": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.4.tgz",
+			"integrity": "sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==",
+			"dev": true,
+			"requires": {
+				"@nodelib/fs.stat": "^2.0.2",
+				"@nodelib/fs.walk": "^1.2.3",
+				"glob-parent": "^5.1.0",
+				"merge2": "^1.3.0",
+				"micromatch": "^4.0.2",
+				"picomatch": "^2.2.1"
+			}
+		},
 		"fast-json-stable-stringify": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -4932,6 +5026,15 @@
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
 			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
 			"dev": true
+		},
+		"fastq": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.10.0.tgz",
+			"integrity": "sha512-NL2Qc5L3iQEsyYzweq7qfgy5OtXCmGzGvhElGEd/SoFWEMOEczNh5s5ocaF01HDetxz+p8ecjNPA6cZxxIHmzA==",
+			"dev": true,
+			"requires": {
+				"reusify": "^1.0.4"
+			}
 		},
 		"fb-watchman": {
 			"version": "2.0.1",
@@ -5315,6 +5418,28 @@
 			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
 			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
 			"dev": true
+		},
+		"globby": {
+			"version": "11.0.1",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-11.0.1.tgz",
+			"integrity": "sha512-iH9RmgwCmUJHi2z5o2l3eTtGBtXek1OYlHrbcxOYugyHLmAsZrPj43OtHThd62Buh/Vv6VyCBD2bdyWcGNQqoQ==",
+			"dev": true,
+			"requires": {
+				"array-union": "^2.1.0",
+				"dir-glob": "^3.0.1",
+				"fast-glob": "^3.1.1",
+				"ignore": "^5.1.4",
+				"merge2": "^1.3.0",
+				"slash": "^3.0.0"
+			},
+			"dependencies": {
+				"ignore": {
+					"version": "5.1.8",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+					"integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+					"dev": true
+				}
+			}
 		},
 		"got": {
 			"version": "9.6.0",
@@ -8082,6 +8207,12 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
 			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+			"dev": true
+		},
+		"merge2": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+			"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
 			"dev": true
 		},
 		"micromatch": {
@@ -11493,6 +11624,12 @@
 			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
 			"dev": true
 		},
+		"reusify": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+			"integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+			"dev": true
+		},
 		"rgb-regex": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/rgb-regex/-/rgb-regex-1.0.1.tgz",
@@ -11536,6 +11673,12 @@
 			"version": "4.8.5",
 			"resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
 			"integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
+			"dev": true
+		},
+		"run-parallel": {
+			"version": "1.1.10",
+			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.10.tgz",
+			"integrity": "sha512-zb/1OuZ6flOlH6tQyMPUrE3x3Ulxjlo9WIVXR4yVYi4H9UXQaeIsPbLn2R3O3vQCnDKkAl2qHiuocKKX4Tz/Sw==",
 			"dev": true
 		},
 		"rx": {

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
 		"@babel/plugin-transform-modules-commonjs": "^7.10.4",
 		"@rollup/plugin-alias": "^3.1.1",
 		"@rollup/plugin-commonjs": "^14.0.0",
+		"@rollup/plugin-dynamic-import-vars": "^1.1.1",
 		"@rollup/plugin-json": "^4.1.0",
 		"@rollup/plugin-node-resolve": "^8.1.0",
 		"@rollup/plugin-virtual": "^2.0.3",

--- a/src/bundler.js
+++ b/src/bundler.js
@@ -147,7 +147,7 @@ export async function bundleProd({
 			return fileName;
 		},
 		hoistTransitiveImports: true,
-		plugins: minify ? [terser({ compress: true, sourcemap })] : [],
+		plugins: [minify && terser({ compress: true, sourcemap })],
 		sourcemap,
 		sourcemapPathTransform(p, mapPath) {
 			let url = pathToPosix(relative(cwd, resolve(dirname(mapPath), p)));

--- a/src/bundler.js
+++ b/src/bundler.js
@@ -130,9 +130,7 @@ export async function bundleProd({
 			optimizeGraphPlugin({ publicPath }),
 			minify && minifyCssPlugin({ sourcemap }),
 			copyAssetsPlugin({ cwd })
-		]
-			.concat(plugins || [])
-			.filter(Boolean)
+		])
 	});
 
 	/** @type {import('rollup').OutputOptions} */

--- a/src/bundler.js
+++ b/src/bundler.js
@@ -101,7 +101,10 @@ export async function bundleProd({
 				production: true
 			}),
 			htmlEntriesPlugin({ cwd, publicDir, publicPath }),
-			(dynamicImportVars.default || dynamicImportVars)({ exclude: 'node_modules' }),
+			(dynamicImportVars.default || dynamicImportVars)({
+				include: /\.(m?jsx?|tsx?)$/,
+				exclude: /\/node_modules\//
+			}),
 			publicPathPlugin({ publicPath }),
 			aliasesPlugin({ aliases, cwd: root }),
 			htmPlugin({ production: true }),

--- a/test/fixtures/dynamic-import/index.html
+++ b/test/fixtures/dynamic-import/index.html
@@ -1,0 +1,1 @@
+<script src="./index.js" type="module"></script>

--- a/test/fixtures/dynamic-import/index.js
+++ b/test/fixtures/dynamic-import/index.js
@@ -1,0 +1,11 @@
+console.log('hello from index.js');
+const pages = ['one', 'two'];
+const mods = Promise.all(pages.map(page => import(`./pages/${page}.js`))).then(m => {
+	console.log('loaded pages');
+	console.log(m.map(m => m.default).join());
+});
+
+export async function prerender() {
+	await mods;
+	return { html: 'nothing here' };
+}

--- a/test/fixtures/dynamic-import/pages/one.js
+++ b/test/fixtures/dynamic-import/pages/one.js
@@ -1,0 +1,2 @@
+console.log('hello from page one');
+export default 'page one';

--- a/test/fixtures/dynamic-import/pages/two.js
+++ b/test/fixtures/dynamic-import/pages/two.js
@@ -1,0 +1,2 @@
+console.log('hello from page two');
+export default 'page two';


### PR DESCRIPTION
This makes it possible to use variables in dynamic imports in production, not just in development:

```js
const pages = await ['one', 'two'].map(page => import(`./pages/${page}.js`))
```

FWIW I'm not super thrilled with the performance of this off-the-shelf plugin - it pulls in a bunch of new dependencies for scanning the disk via path globs, but our use-case doesn't really necessitate them. A simplified version could be written on top of `totalist`, which we're already using. It also unconditionally invokes `this.parse()` on every module, which could be avoided by ignoring modules that don't match a basic pattern like `\bimport\s*(\/\*[\s\S]*?\*\/)\s*\(`. If performance tanks, this could also just be done by wrapping the rollup plugin:

```js
import _dynamicImportVars from '@rollup/plugin-dynamic-import-vars';
function dynamicImportVars(opts) {
  const p = (_dynamicImportVars.default || _dynamicImportVars)(opts);
  function transform(code, id) {
    if (!/\.(m?jsx?|tsx?)$/i.test(id) || !/\bimport\s*(\/\*[\s\S]*?\*\/)\s*\(/.test(code)) return;
    return p.transform.apply(this, arguments);
  }
  return { ...p, transform };
}
```

Fixes #286.