### PR TITLE
feat: close Rollup bundle before passing output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11652,12 +11652,21 @@
 			}
 		},
 		"rollup": {
-			"version": "2.21.0",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.21.0.tgz",
-			"integrity": "sha512-BEGgy+wSzux7Ycq58pRiWEOBZaXRXTuvzl1gsm7gqmsAHxkWf9nyA5V2LN9fGSHhhDQd0/C13iRzSh4bbIpWZQ==",
+			"version": "2.39.0",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.39.0.tgz",
+			"integrity": "sha512-+WR3bttcq7zE+BntH09UxaW3bQo3vItuYeLsyk4dL2tuwbeSKJuvwiawyhEnvRdRgrII0Uzk00FpctHO/zB1kw==",
 			"dev": true,
 			"requires": {
-				"fsevents": "~2.1.2"
+				"fsevents": "~2.3.1"
+			},
+			"dependencies": {
+				"fsevents": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+					"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+					"dev": true,
+					"optional": true
+				}
 			}
 		},
 		"rollup-plugin-preserve-shebang": {

--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
 		"premove": "^3.0.1",
 		"prettier": "^2.0.5",
 		"puppeteer": "^3.3.0",
-		"rollup": "^2.21.0",
+		"rollup": "^2.39.0",
 		"rollup-plugin-preserve-shebang": "^1.0.1",
 		"sade": "^1.7.3",
 		"semver": "^7.3.2",

--- a/src/bundler.js
+++ b/src/bundler.js
@@ -177,6 +177,8 @@ export async function bundleProd({
 		}
 	}
 
+	await bundle.close();
+
 	return result;
 }
 


### PR DESCRIPTION
Closes the Rollup bundle before passing the output, no internal WMR plugins uses the `closeBundle` hook yet, so this is mainly oriented towards user adding their own plugins.