### PR TITLE
Increase HTTP/1 Keep-Alive timeout from 5s to 60s

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -79,6 +79,7 @@ export default async function server({ cwd, root, overlayDir, middleware, http2,
 	}
 	if (!app.server) {
 		app.server = createServer();
+		app.server.keepAliveTimeout = 60 * 1000;
 		app.http2 = false;
 	}
 


### PR DESCRIPTION
Our server is 99% intended for development use, where there is little reason to have keep-alive connections expire.