### PR TITLE
Fix multiple dashes in css modules

### DIFF
--- a/src/plugins/wmr/styles-plugin.js
+++ b/src/plugins/wmr/styles-plugin.js
@@ -142,7 +142,7 @@ export default function wmrStylesPlugin({ cwd, hot, fullPath } = {}) {
 				.map(m => {
 					const matches = m.match(/^(['"]?)([^:'"]+?)\1:(.+)$/);
 					if (!matches) return;
-					let name = matches[2].replace(/-[a-z]/gi, s => s[1].toUpperCase());
+					let name = matches[2].replace(/-+[a-z]/gi, s => s[s.length - 1].toUpperCase());
 					if (name.match(/^\d/)) name = '$' + name;
 					return name + '=' + matches[3];
 				})

--- a/src/plugins/wmr/styles-plugin.js
+++ b/src/plugins/wmr/styles-plugin.js
@@ -142,7 +142,7 @@ export default function wmrStylesPlugin({ cwd, hot, fullPath } = {}) {
 				.map(m => {
 					const matches = m.match(/^(['"]?)([^:'"]+?)\1:(.+)$/);
 					if (!matches) return;
-					let name = matches[2].replace(/-+[a-z]/gi, s => s[s.length - 1].toUpperCase());
+					let name = matches[2].replace(/-+([a-z])/gi, (s, c) => c.toUpperCase());
 					if (name.match(/^\d/)) name = '$' + name;
 					return name + '=' + matches[3];
 				})


### PR DESCRIPTION
Enjoying playing around with with this, thanks!

Ran into an issue with css module class names that contain multiple dashes (e.g. BEM).

This is only half a fix, as there’s still the possibility of an overlap (‘foo-bar’ and ‘foo--bar’), but this is less likely the multiple dash case. Short of replacing -- with something even less likely to occur, I wasn’t sure of a better solution!