### PR TITLE
Bugfix: `wmr serve` should support middleware option

### DIFF
--- a/src/serve.js
+++ b/src/serve.js
@@ -20,6 +20,7 @@ import sirv from 'sirv';
  * @property {string} [port]
  * @property {boolean} [http2]
  * @property {boolean|number} [compress]
+ * @property {polka.Middleware[]} [middleware] Additional Polka middlewares to inject
  * @property {Record<string, string>} [env]
  */
 

--- a/src/serve.js
+++ b/src/serve.js
@@ -60,7 +60,7 @@ export default async function serve(options = {}) {
 		app.use(compression({ threshold }));
 	}
 
-	if (options.middleware) {
+	if (options.middleware && options.middleware.length) {
 		app.use(...options.middleware);
 	}
 

--- a/src/serve.js
+++ b/src/serve.js
@@ -60,6 +60,10 @@ export default async function serve(options = {}) {
 		app.use(compression({ threshold }));
 	}
 
+	if (options.middleware) {
+		app.use(...options.middleware);
+	}
+
 	app.use(
 		sirv(options.out, {
 			single: true,


### PR DESCRIPTION
For some reason I didn't catch this - `wmr serve` doesn't use `server.js` to instantiate its web server (it probably should?), which meant it was never registering middlewares.