### PR TITLE
Preact-ISO fix: Adding peerDeps & correcting module type

### DIFF
--- a/packages/preact-iso/package.json
+++ b/packages/preact-iso/package.json
@@ -5,6 +5,7 @@
 	"main": "./index.js",
 	"module": "./index.js",
 	"types": "./index.d.ts",
+	"type": "module",
 	"exports": {
 		".": "./index.js",
 		"./router": "./router.js",
@@ -22,5 +23,9 @@
 	"devDependencies": {
 		"preact": "^10.5.7",
 		"preact-render-to-string": "^5.1.12"
+	},
+	"peerDependencies": {
+		"preact": ">=10",
+		"preact-render-to-string": ">=5"
 	}
 }


### PR DESCRIPTION
Using `preact-iso` outside of WMR will lead to issues when `preact` and `preact-render-to-string` don't get auto-magically imported. Adding them as peerDeps will at least throw a warning to the user that they're needed.

As far as I know, the `type: module` should be needed when using this from Node, else Node will assume CJS.