### PR TITLE
refactor: Adding 'preact' as a dependency to create-wmr template

### DIFF
--- a/.changeset/smooth-needles-poke.md
+++ b/.changeset/smooth-needles-poke.md
@@ -1,0 +1,5 @@
+---
+'create-wmr': patch
+---
+
+Create-WMR now has matching install ranges for pkg-install & the templated package.json file

--- a/packages/create-wmr/src/index.js
+++ b/packages/create-wmr/src/index.js
@@ -38,7 +38,7 @@ sade('create-wmr [dir]', true)
 			process.stderr.write(`\n${red(`${packageManager} cannot be found`)}\n`);
 			process.exit(1);
 		});
-		await install(['wmr@^1.2.0', 'preact@^10.5.12', 'preact-iso@0.x'], { prefer: packageManager, cwd });
+		await install(['wmr@^1.2.0', 'preact@^10.5.12', 'preact-iso@^1.0.0'], { prefer: packageManager, cwd });
 		spinner.succeed('installed WMR.');
 
 		if (opts.eslint) {

--- a/packages/create-wmr/src/index.js
+++ b/packages/create-wmr/src/index.js
@@ -38,7 +38,7 @@ sade('create-wmr [dir]', true)
 			process.stderr.write(`\n${red(`${packageManager} cannot be found`)}\n`);
 			process.exit(1);
 		});
-		await install(['wmr', 'preact', 'preact-iso'], { prefer: packageManager, cwd });
+		await install(['wmr@^1.2.0', 'preact@^10.5.12', 'preact-iso@0.x'], { prefer: packageManager, cwd });
 		spinner.succeed('installed WMR.');
 
 		if (opts.eslint) {

--- a/packages/create-wmr/tpl/package.json
+++ b/packages/create-wmr/tpl/package.json
@@ -13,7 +13,7 @@
 	},
 	"dependencies": {
 		"preact": "^10.5.12",
-		"preact-iso": "0.x"
+		"preact-iso": "^1.0.0"
 	},
 	"devDependencies": {
 		"wmr": "^1.2.0"

--- a/packages/create-wmr/tpl/package.json
+++ b/packages/create-wmr/tpl/package.json
@@ -12,10 +12,10 @@
 		"react-dom": "preact/compat"
 	},
 	"dependencies": {
-		"preact": "latest",
-		"preact-iso": "latest"
+		"preact": "^10.5.12",
+		"preact-iso": "0.x"
 	},
 	"devDependencies": {
-		"wmr": "latest"
+		"wmr": "^1.2.0"
 	}
 }

--- a/packages/create-wmr/tpl/package.json
+++ b/packages/create-wmr/tpl/package.json
@@ -12,10 +12,10 @@
 		"react-dom": "preact/compat"
 	},
 	"dependencies": {
-		"preact": "^10.5.12",
-		"preact-iso": "^0.2.0"
+		"preact": "latest",
+		"preact-iso": "latest"
 	},
 	"devDependencies": {
-		"wmr": "^1.0.0"
+		"wmr": "latest"
 	}
 }

--- a/packages/create-wmr/tpl/package.json
+++ b/packages/create-wmr/tpl/package.json
@@ -12,7 +12,8 @@
 		"react-dom": "preact/compat"
 	},
 	"dependencies": {
-		"preact-iso": "^1.0.0"
+		"preact": "^10.5.12",
+		"preact-iso": "^0.2.0"
 	},
 	"devDependencies": {
 		"wmr": "^1.0.0"


### PR DESCRIPTION
This isn't necessarily needed, but seeing as how [`preact` is installed by `create-wmr`](https://github.com/preactjs/wmr/blob/247c7b291fbb4b684d6b3c566135ada5513ed9a3/packages/create-wmr/src/index.js#L41), I think it should probably be listed as a dependency? Especially if any inference like mentioned in https://github.com/preactjs/wmr/pull/322#issuecomment-770534992 is later added. 