### PR TITLE
Fix brittle regex in optimize-graph-plugin

### DIFF
--- a/src/plugins/optimize-graph-plugin.js
+++ b/src/plugins/optimize-graph-plugin.js
@@ -479,7 +479,7 @@ function constructAssetToChunkMap(bundle) {
  * @param {(fn: string, url: string, quote: string) => string | null | undefined} replacer Return replacement code, or `null`/`undefined` to preserve the matched call.
  */
 function replaceSimpleFunctionCall(code, replacer) {
-	return code.replace(/([a-z$_][a-z0-9$_]*)\((['"`])(.*?)\2\)/gi, (s, fn, quote, url) => {
+	return code.replace(/([a-z$_][a-z0-9$_]*)\((['"`])((?:(?!\2)[^\\]|\\.)*?)\2\)/gi, (s, fn, quote, url) => {
 		const ret = replacer(fn, url, quote);
 		return ret == null ? s : ret;
 	});

--- a/src/plugins/optimize-graph-plugin.js
+++ b/src/plugins/optimize-graph-plugin.js
@@ -479,7 +479,7 @@ function constructAssetToChunkMap(bundle) {
  * @param {(fn: string, url: string, quote: string) => string | null | undefined} replacer Return replacement code, or `null`/`undefined` to preserve the matched call.
  */
 function replaceSimpleFunctionCall(code, replacer) {
-	return code.replace(/([a-z$_][a-z0-9$_]*)\((['"`])((?:(?!\2)[^\\]|\\.)*?)\2\)/gi, (s, fn, quote, url) => {
+	return code.replace(/(?<![.\w])([a-z$_][\w$]*)\((['"`])((?:(?!\2)[^\\]|\\.)*?)\2\)/gi, (s, fn, quote, url) => {
 		const ret = replacer(fn, url, quote);
 		return ret == null ? s : ret;
 	});


### PR DESCRIPTION
This fixes #327 

The previous regex was too greedy and would break if it came across a function with multiple arguments where the first was a string and the last was _not_ a string.

[Here's](https://regexr.com/5lpav) what the previous regex was doing, occasionally causing paths not to be picked up.

And [here's](https://regexr.com/5lpb8) the proposed version, which makes sure it can't accidentally go past the end of a string.

I wasn't sure how best to add tests for this though, happy to try and add something based off the repro case I found in #327 