### PR TITLE
Fix HMR not working with CSS on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"demo": "cd demo && node --experimental-modules ../src/cli.js 2>&1",
 		"demo:prod": "cd demo && node --experimental-modules ../src/cli.js build --prerender 2>&1",
 		"demo:serve": "cd demo && node --experimental-modules ../src/cli.js serve",
-		"dev": "PROFILE=true nodemon -w src --exec \"npm run -s demo\"",
+		"dev": "cross-env PROFILE=true nodemon -w src --exec \"npm run -s demo\"",
 		"build": "rollup -c",
 		"ci": "npm run build && cd demo && node ../wmr.cjs build --prerender",
 		"prepack": "node --experimental-modules ./src/lib/~publish.js",

--- a/packages/preact-iso/package.json
+++ b/packages/preact-iso/package.json
@@ -5,6 +5,7 @@
 	"main": "./index.js",
 	"module": "./index.js",
 	"types": "./index.d.ts",
+	"type": "module",
 	"exports": {
 		".": "./index.js",
 		"./router": "./router.js",
@@ -22,5 +23,9 @@
 	"devDependencies": {
 		"preact": "^10.5.7",
 		"preact-render-to-string": "^5.1.12"
+	},
+	"peerDependencies": {
+		"preact": ">=10",
+		"preact-render-to-string": ">=5"
 	}
 }


### PR DESCRIPTION
I fixed a bug that only affects windows devices, where some files were triggering HMR but sending old changes to the browser.

**What caused it?**
The cause was that .css and .css.js files cache keys were not being normalized when saved, but only when being removed from **WRITE_CACHE**. Making the server always return old cached CSS files cause of the "\\" Windows path separator.

**How did I solve it?**
I created the **getCacheKeyById** function at the top of **wmr-middleware.js** file and used it on js, css and cssModule transforms functions for cacheKey normalization.

I also added **cross-env** to the dev script for Windows compatibility.

[This](https://github.com/preactjs/wmr/issues/246#issuecomment-748804874) issue helped me to find out the problem.