### PR TITLE
Fix assets bad url on dev mode Windows

### DIFF
--- a/src/plugins/url-plugin.js
+++ b/src/plugins/url-plugin.js
@@ -1,4 +1,4 @@
-import { relative, basename } from 'path';
+import { relative, basename, sep, posix } from 'path';
 import { promises as fs } from 'fs';
 
 const IMPLICIT_URL = /\.(?:png|jpe?g|gif|webp|svg|mp4|webm|ogg|mp3|wav|flac|aac|woff2?|eot|ttf|otf)$/i;
@@ -35,7 +35,7 @@ export default function urlPlugin({ inline, cwd } = {}) {
 
 			// In dev mode, we turn the import into an inline module that avoids a network request:
 			if (inline) {
-				const url = '/' + relative(cwd, resolved.id).replace(/^\./, '') + '?asset';
+				const url = '/' + relative(cwd, resolved.id).replace(/^\./, '').split(sep).join(posix.sep) + '?asset';
 				return {
 					id: escapeUrl(`data:text/javascript,export default${JSON.stringify(url)}`),
 					external: true


### PR DESCRIPTION
I fixed a bug that only affects dev mode in Windows devices, where assets were pointing to bad urls cause of Windows backslash path separator.

**What caused it?**
The cause was that url paths to assets weren't being normalized when building inline modules. Generating modules like this:
![image](https://user-images.githubusercontent.com/43894343/107883923-ad9e0780-6ed0-11eb-9dd1-6ca499339e3b.png)
Pointing to paths that don't exist:
![image](https://user-images.githubusercontent.com/43894343/107883967-f229a300-6ed0-11eb-8697-a17f66223589.png)