### PR TITLE
ci: Revising workflow files

### DIFF
--- a/.github/workflows/compressed-size.yml
+++ b/.github/workflows/compressed-size.yml
@@ -1,7 +1,10 @@
 name: compressed-size
 on:
   pull_request:
-    branches: [main]
+    branches: 
+      - main
+    paths:
+      - packages/wmr/**
 
 jobs:
   build:
@@ -12,7 +15,7 @@ jobs:
       - name: compressed-size-action
         uses: preactjs/compressed-size-action@v2
         with:
-          pattern: 'packages/demo/{wmr.cjs,demo/dist/**/*.{js,css,html}}'
+          pattern: 'packages/wmr/{wmr.cjs,demo/dist/**/*.{js,css,html}}'
           build-script: ci
           strip-hash: "\\.(\\w{8})\\.(?:js|css)$"
           repo-token: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,8 +3,12 @@ name: CI
 on:
   push:
     branches:
-    - main
+      - main
+    paths:
+      - packages/wmr/**
   pull_request:
+    paths:
+      - packages/wmr/**
 
 jobs:
   build:


### PR DESCRIPTION
The Compressed-Size workflow had an incorrect pattern that needed to be fixed. 

This also limits the WMR build/lint/test & Compressed-Size workflows to only run when appropriate. As of now, they only are concerned about content within `packages/wmr` so the workflows paths have been updated to match. They won't run when `preact-iso` or `create-wmr` have changes.