### PR TITLE
Router params: use Jest's ESM support

### DIFF
--- a/packages/preact-iso/package.json
+++ b/packages/preact-iso/package.json
@@ -7,12 +7,7 @@
 	"types": "./index.d.ts",
 	"type": "module",
 	"scripts": {
-		"test": "jest"
-	},
-	"babel": {
-		"plugins": [
-			"@babel/plugin-transform-modules-commonjs"
-		]
+		"test": "node --experimental-vm-modules node_modules/.bin/jest"
 	},
 	"exports": {
 		".": "./index.js",
@@ -29,8 +24,6 @@
 	},
 	"license": "MIT",
 	"devDependencies": {
-		"@babel/plugin-transform-modules-commonjs": "7.12.13",
-		"babel-jest": "^26.1.0",
 		"jest": "26.6.3",
 		"preact": "^10.5.7",
 		"preact-render-to-string": "^5.1.12"

--- a/yarn.lock
+++ b/yarn.lock
@@ -607,7 +607,7 @@
     "@babel/helper-plugin-utils" "^7.12.13"
     babel-plugin-dynamic-import-node "^2.3.3"
 
-"@babel/plugin-transform-modules-commonjs@7.12.13", "@babel/plugin-transform-modules-commonjs@^7.10.4", "@babel/plugin-transform-modules-commonjs@^7.12.13":
+"@babel/plugin-transform-modules-commonjs@^7.10.4", "@babel/plugin-transform-modules-commonjs@^7.12.13":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.12.13.tgz#5043b870a784a8421fa1fd9136a24f294da13e50"
   integrity sha512-OGQoeVXVi1259HjuoDnsQMlMkT9UkZT9TpXAsqWplS/M0N1g3TJAn/ByOCeQu7mfjc5WpSsRU+jV1Hd89ts0kQ==


### PR DESCRIPTION
Jest [supports Node's native ESM](https://jestjs.io/docs/en/ecmascript-modules) now, and it seems to work nicely! A quick test shows it's around 30% faster, which is pretty nice.