### PR TITLE
Bugfix:router hydration duplication

### DIFF
--- a/.changeset/silly-shrimps-build.md
+++ b/.changeset/silly-shrimps-build.md
@@ -1,0 +1,5 @@
+---
+"preact-iso": patch
+---
+
+Fixes a bug introduced in 1.0.0 where Router would duplicate DOM when hydrating `lazy()` components.

--- a/packages/preact-iso/router.js
+++ b/packages/preact-iso/router.js
@@ -77,7 +77,9 @@ export function Router(props) {
 	const prevChildren = useRef();
 	const pending = useRef();
 
+	let reverse = false;
 	if (url !== cur.current.url) {
+		reverse = true;
 		pending.current = null;
 		prev.current = cur.current;
 		prevChildren.current = curChildren.current;
@@ -119,7 +121,7 @@ export function Router(props) {
 
 	// Hi! Wondering what this horrid line is for? That's totally reasonable, it is gross.
 	// It prevents the old route from being remounted because it got shifted in the children Array.
-	if (this.__v && this.__v.__k) this.__v.__k.reverse();
+	if (reverse && this.__v && this.__v.__k) this.__v.__k.reverse();
 
 	return [curChildren.current, prevChildren.current];
 }


### PR DESCRIPTION
The router flicker fix from #358 and #337 didn't account for hydration, and was resulting in `lazy()` components being deopted out of hydration and their contents duplicated. This fixes that issue by only applying the VNode reorder workaround to client-side route transitions.