### PR TITLE
refactor: create-wmr checks dir before installing

### DIFF
--- a/.changeset/grumpy-pens-decide.md
+++ b/.changeset/grumpy-pens-decide.md
@@ -1,0 +1,5 @@
+---
+'create-wmr': minor
+---
+
+Blocks accidentally creating a new WMR project into a directory that already exists

--- a/packages/create-wmr/src/index.js
+++ b/packages/create-wmr/src/index.js
@@ -11,12 +11,19 @@ const { dim, bold, cyan, red } = kleur;
 
 sade('create-wmr [dir]', true)
 	.option('--eslint', 'Set up the Preact ESLint configuration (takes a lot longer)', false)
+	.option('--force', 'Force install into an existing directory', false)
 	.describe('Initialize a WMR project')
 	.example('npm init wmr ./some-directory')
 	.action(async (dir, opts) => {
 		const origCwd = process.cwd();
 		let cwd = process.cwd();
 		if (dir) {
+			if ((await fs.stat(dir)).isDirectory() && !opts.force) {
+				process.stderr.write(
+					`${red(`Refusing to overwrite directory! Please specify a different directory or use the '--force' flag`)}\n`
+				);
+				process.exit(1);
+			}
 			cwd = resolve(cwd, dir || '.');
 			await fs.mkdir(cwd, { recursive: true });
 			process.chdir(cwd);


### PR DESCRIPTION
After blowing up another project with an accidental `npm init`, I remembered this bug (?). Not sure if we really want this behavior or not, so I thought I'd bring this back up. 

The implementation here is pretty much swiped from `preact-cli`. Not a huge fan of another flag, but just an idea. 