### PR TITLE
preact-iso: Fix hydrate parent definition

### DIFF
--- a/.changeset/smart-ways-rule.md
+++ b/.changeset/smart-ways-rule.md
@@ -1,0 +1,5 @@
+---
+'preact-iso': patch
+---
+
+Fix hydrate parent definition

--- a/packages/preact-iso/hydrate.d.ts
+++ b/packages/preact-iso/hydrate.d.ts
@@ -1,3 +1,3 @@
 import { ComponentChild, VNode } from 'preact';
 
-export default function hydrate(jsx: ComponentChild, parent?: VNode): void;
+export default function hydrate(jsx: ComponentChild, parent?: Element | Document | ShadowRoot | DocumentFragment): void;


### PR DESCRIPTION
This fixes `parent` argument definition to be compatible with [`preact.render`](https://github.com/preactjs/preact/blob/10.5.12/src/index.d.ts#L226) and [`preact.hydrate`](https://github.com/preactjs/preact/blob/10.5.12/src/index.d.ts#L231) which are called under the hood:

Use case:

```jsx
// Argument of type 'HTMLElement' is not assignable to parameter of type 'VNode<{}>'.
hydrate(<App />, document.body)
```