### PR TITLE
fix: Uncaught fs.stat() throw

### DIFF
--- a/.changeset/plenty-baboons-sort.md
+++ b/.changeset/plenty-baboons-sort.md
@@ -1,0 +1,5 @@
+---
+'create-wmr': patch
+---
+
+Fixes create-wmr so that it can be used with a new directory

--- a/packages/create-wmr/src/index.js
+++ b/packages/create-wmr/src/index.js
@@ -19,8 +19,7 @@ sade('create-wmr [dir]', true)
 		let cwd = process.cwd();
 		if (dir) {
 			try {
-				(await fs.stat(dir)).isDirectory();
-				if (!opts.force) {
+				if ((await fs.stat(dir)).isDirectory() && !opts.force) {
 					process.stderr.write(
 						`${red(
 							`Refusing to overwrite directory! Please specify a different directory or use the '--force' flag`

--- a/packages/create-wmr/src/index.js
+++ b/packages/create-wmr/src/index.js
@@ -18,12 +18,17 @@ sade('create-wmr [dir]', true)
 		const origCwd = process.cwd();
 		let cwd = process.cwd();
 		if (dir) {
-			if ((await fs.stat(dir)).isDirectory() && !opts.force) {
-				process.stderr.write(
-					`${red(`Refusing to overwrite directory! Please specify a different directory or use the '--force' flag`)}\n`
-				);
-				process.exit(1);
-			}
+			try {
+				(await fs.stat(dir)).isDirectory();
+				if (!opts.force) {
+					process.stderr.write(
+						`${red(
+							`Refusing to overwrite directory! Please specify a different directory or use the '--force' flag`
+						)}\n`
+					);
+					process.exit(1);
+				}
+			} catch {}
 			cwd = resolve(cwd, dir || '.');
 			await fs.mkdir(cwd, { recursive: true });
 			process.chdir(cwd);


### PR DESCRIPTION
If the directory does not exist, `fs.stat()` will throw and currently that's uncaught.

Not sure how I missed this