### PR TITLE
Fix/catch mkdir error

### DIFF
--- a/.changeset/nervous-cars-teach.md
+++ b/.changeset/nervous-cars-teach.md
@@ -1,0 +1,5 @@
+---
+'create-wmr': patch
+---
+
+Catch when mkdir throws due to a file existing with the specified directory name

--- a/packages/create-wmr/src/index.js
+++ b/packages/create-wmr/src/index.js
@@ -25,7 +25,16 @@ sade('create-wmr [dir]', true)
 				process.exit(1);
 			}
 			cwd = resolve(cwd, dir || '.');
-			await fs.mkdir(cwd, { recursive: true });
+			try {
+				await fs.mkdir(cwd, { recursive: true });
+			} catch {
+				process.stderr.write(
+					`${red(
+						`There is already a file with the same name as the directory you specified. Please provide a different directory name`
+					)}\n`
+				);
+				process.exit(1);
+			}
 			process.chdir(cwd);
 		}
 		const ctx = {


### PR DESCRIPTION
If `foobar` exists as a file, `mkdir()` will throw due to being unable to create a directory with the same name. 