### PR TITLE
(wmr) - transpile prefresh-registrations

### DIFF
--- a/packages/wmr/demo/public/index.tsx
+++ b/packages/wmr/demo/public/index.tsx
@@ -21,7 +21,7 @@ const ClassFields = lazy(() => import('./pages/class-fields.js'));
 const Files = lazy(() => import('./pages/files/index.js'));
 const Environment = lazy(async () => (await import('./pages/environment/index.js')).Environment);
 
-export function App() {
+function App() {
 	return (
 		<LocationProvider>
 			<div class="app">
@@ -51,6 +51,3 @@ export async function prerender(data) {
 	const { prerender } = await import('./lib/prerender.js');
 	return await prerender(<App {...data} />);
 }
-
-// @ts-ignore
-if (module.hot) module.hot.accept(u => render(<u.module.App />, document.body));

--- a/packages/wmr/demo/public/index.tsx
+++ b/packages/wmr/demo/public/index.tsx
@@ -2,10 +2,8 @@ import { LocationProvider, Router } from './lib/loc.js';
 import lazy, { ErrorBoundary } from './lib/lazy.js';
 import hydrate from './lib/hydrate';
 import Home from './pages/home.js';
-// import About from './pages/about/index.js';
 import NotFound from './pages/_404.js';
 import Header from './header.tsx';
-// import './style.css';
 
 const About = lazy(() => import('./pages/about/index.js'));
 const LazyAndLate = lazy(

--- a/packages/wmr/src/lib/acorn-traverse.js
+++ b/packages/wmr/src/lib/acorn-traverse.js
@@ -337,8 +337,6 @@ class Path {
 			let str = generate(node, this.ctx);
 			this._hasString = true;
 			this.ctx.out.overwrite(this.start, this.end, str, { storeName: true });
-			this.end = str.length;
-			this.ctx.out = new MagicString(this.ctx?.out.toString());
 		}
 		this._requeue();
 	}
@@ -391,7 +389,9 @@ class Path {
 			if (p) p.key = index;
 		}
 		// create a Path entry for the inserted node, and regenerate the container:
-		child._regenerateParent();
+		if (!this._regenerateParent()) {
+			this._regenerate();
+		}
 	}
 
 	_regenerate() {

--- a/packages/wmr/src/lib/acorn-traverse.js
+++ b/packages/wmr/src/lib/acorn-traverse.js
@@ -179,6 +179,7 @@ for (let type in codeGenerator) {
 			}
 		}
 
+		// TODO: this seems to have an issue with "ExpressionStatement".expression because "node.expression.left" isn't there
 		fn.call(this, node, state);
 	};
 }
@@ -368,7 +369,12 @@ class Path {
 	}
 
 	insertAfter(node) {
-		// TODO: implement
+		if (!this.parentPath) return;
+
+		const parentNode = this.parentPath.node;
+		const index = parentNode.body.findIndex(x => x === this.node);
+		parentNode.body.splice(index, 0, node);
+		this._regenerateParent();
 	}
 
 	_regenerate() {
@@ -430,7 +436,7 @@ const TYPES = {
 		}
 		return clone;
 	},
-	variableDeclarator: id => ({ type: 'VariableDeclarator', id }),
+	variableDeclaration: (kind, declarations) => ({ type: 'VariableDeclaration', kind, declarations }),
 	identifier: name => ({ type: 'Identifier', name }),
 	stringLiteral: value => ({ type: 'StringLiteral', value }),
 	booleanLiteral: value => ({ type: 'BooleanLiteral', value }),

--- a/packages/wmr/src/lib/acorn-traverse.js
+++ b/packages/wmr/src/lib/acorn-traverse.js
@@ -319,6 +319,7 @@ class Path {
 				ancestors.push(prev);
 			}
 		}
+
 		return Array.isArray(node) ? node.map(x => new Path(x, ancestors, this.ctx)) : new Path(node, ancestors, this.ctx);
 	}
 

--- a/packages/wmr/src/lib/acorn-traverse.js
+++ b/packages/wmr/src/lib/acorn-traverse.js
@@ -624,10 +624,11 @@ function visit(root, visitors, state) {
  * @param {object} options
  * @param {string} options.code
  * @param {MagicString} options.out
+ * @param {string} options.filename
  * @param {typeof DEFAULTS['parse']} options.parse
  * @param {{ compact?: boolean }} options.generatorOpts
  */
-function createContext({ code, out, parse, generatorOpts }) {
+function createContext({ code, out, parse, generatorOpts, filename }) {
 	const ctx = {
 		paths: new WeakMap(),
 		/** @type {Set<Path>} */
@@ -639,7 +640,8 @@ function createContext({ code, out, parse, generatorOpts }) {
 		types,
 		visit,
 		template,
-		Path
+		Path,
+		filename
 	};
 
 	const bound = { ctx };
@@ -689,7 +691,7 @@ export function transform(
 	parse = parse || DEFAULTS.parse;
 	generatorOpts = generatorOpts || {};
 	const out = new MagicString(code);
-	const { types, template, visit } = createContext({ code, out, parse, generatorOpts });
+	const { types, template, visit } = createContext({ code, out, parse, generatorOpts, filename });
 
 	const allPlugins = [];
 	resolvePreset({ presets, plugins }, allPlugins);

--- a/packages/wmr/src/lib/acorn-traverse.js
+++ b/packages/wmr/src/lib/acorn-traverse.js
@@ -322,9 +322,7 @@ class Path {
 			const name = token[1] || token[2];
 			const prev = node;
 			node = node[name];
-			if (!Array.isArray(node)) {
-				ancestors.push(prev);
-			}
+			ancestors.push(prev);
 		}
 
 		return Array.isArray(node) ? node.map(x => new Path(x, ancestors, this.ctx)) : new Path(node, ancestors, this.ctx);

--- a/packages/wmr/src/lib/acorn-traverse.js
+++ b/packages/wmr/src/lib/acorn-traverse.js
@@ -342,9 +342,7 @@ class Path {
 		if (this._regenerateParent()) {
 			this._hasString = false;
 		} else {
-			let str = generate(node, this.ctx);
-			this._hasString = true;
-			this.ctx.out.overwrite(this.start, this.end, str, { storeName: true });
+			this._regenerate();
 		}
 		this._requeue();
 	}

--- a/packages/wmr/src/lib/acorn-traverse.js
+++ b/packages/wmr/src/lib/acorn-traverse.js
@@ -372,7 +372,7 @@ class Path {
 
 		const parentNode = this.parentPath.node;
 		const index = parentNode.body.findIndex(x => x === this.node);
-		parentNode.body.splice(index, 0, node);
+		parentNode.body.splice(index + 1, 0, node);
 		this._regenerateParent();
 	}
 

--- a/packages/wmr/src/lib/acorn-traverse.js
+++ b/packages/wmr/src/lib/acorn-traverse.js
@@ -351,6 +351,7 @@ class Path {
 		}
 		this._hasString = true;
 		this.ctx.out.overwrite(this.start, this.end, str);
+		this.ctx.out = new MagicString(this.ctx?.out.toString());
 	}
 
 	remove() {

--- a/packages/wmr/src/lib/acorn-traverse.js
+++ b/packages/wmr/src/lib/acorn-traverse.js
@@ -179,7 +179,6 @@ for (let type in codeGenerator) {
 			}
 		}
 
-		// TODO: this seems to have an issue with "ExpressionStatement".expression because "node.expression.left" isn't there
 		fn.call(this, node, state);
 	};
 }
@@ -436,7 +435,9 @@ const TYPES = {
 		}
 		return clone;
 	},
+	assignmentExpression: (operator, left, right) => ({ type: 'AssignmentExpression', operator, left, right }),
 	variableDeclaration: (kind, declarations) => ({ type: 'VariableDeclaration', kind, declarations }),
+	variableDeclarator: id => ({ type: 'VariableDeclarator', id }),
 	identifier: name => ({ type: 'Identifier', name }),
 	stringLiteral: value => ({ type: 'StringLiteral', value }),
 	booleanLiteral: value => ({ type: 'BooleanLiteral', value }),

--- a/packages/wmr/src/lib/acorn-traverse.js
+++ b/packages/wmr/src/lib/acorn-traverse.js
@@ -351,8 +351,6 @@ class Path {
 		}
 		this._hasString = true;
 		this.ctx.out.overwrite(this.start, this.end, str, { storeName: true });
-		this.end = str.length;
-		this.ctx.out = new MagicString(this.ctx?.out.toString());
 	}
 
 	remove() {

--- a/packages/wmr/src/lib/acorn-traverse.js
+++ b/packages/wmr/src/lib/acorn-traverse.js
@@ -191,14 +191,14 @@ for (let type in codeGenerator) {
 }
 
 // Useful for debugging missing AST node serializers
-codeGenerator = new Proxy(codeGenerator, {
-	get(target, key) {
-		if (Reflect.has(target, key)) {
-			return target[key];
-		}
-		throw Error(`No code generator defined for ${key}`);
-	}
-});
+// codeGenerator = new Proxy(codeGenerator, {
+// 	get(target, key) {
+// 		if (Reflect.has(target, key)) {
+// 			return target[key];
+// 		}
+// 		throw Error(`No code generator defined for ${key}`);
+// 	}
+// });
 
 function template(str) {
 	str = String(str);

--- a/packages/wmr/src/lib/acorn-traverse.js
+++ b/packages/wmr/src/lib/acorn-traverse.js
@@ -336,7 +336,9 @@ class Path {
 		} else {
 			let str = generate(node, this.ctx);
 			this._hasString = true;
-			this.ctx.out.overwrite(this.start, this.end, str);
+			this.ctx.out.overwrite(this.start, this.end, str, { storeName: true });
+			this.end = str.length;
+			this.ctx.out = new MagicString(this.ctx?.out.toString());
 		}
 		this._requeue();
 	}
@@ -350,7 +352,8 @@ class Path {
 			return;
 		}
 		this._hasString = true;
-		this.ctx.out.overwrite(this.start, this.end, str);
+		this.ctx.out.overwrite(this.start, this.end, str, { storeName: true });
+		this.end = str.length;
 		this.ctx.out = new MagicString(this.ctx?.out.toString());
 	}
 
@@ -715,8 +718,8 @@ export function transform(
 	parse = parse || DEFAULTS.parse;
 	generatorOpts = generatorOpts || {};
 	const out = new MagicString(code);
-	const { types, template, visit } = createContext({ code, out, parse, generatorOpts, filename });
-
+	const ctx = createContext({ code, out, parse, generatorOpts, filename });
+	const { types, template, visit } = ctx;
 	const allPlugins = [];
 	resolvePreset({ presets, plugins }, allPlugins);
 
@@ -752,7 +755,7 @@ export function transform(
 	let map;
 	function getSourceMap() {
 		if (!map) {
-			map = out.generateMap({
+			map = ctx.out.generateMap({
 				includeContent: false,
 				source: sourceFileName
 			});
@@ -765,7 +768,7 @@ export function transform(
 	}
 
 	return {
-		code: out.toString(),
+		code: ctx.out.toString(),
 		get ast() {
 			return ast === true ? parsed : undefined;
 		},

--- a/packages/wmr/src/lib/acorn-traverse.js
+++ b/packages/wmr/src/lib/acorn-traverse.js
@@ -370,11 +370,11 @@ class Path {
 	insertAfter(node) {
 		if (!this.parentPath) return;
 
-		const parentNode = this.parentPath.node;
 		let child = this;
 		while (child && !child.inList) {
 			child = child.parentPath;
 		}
+
 		if (!child) throw Error('Failed to insert node: no parent container');
 
 		// insert the child into the the container at the next index:
@@ -387,9 +387,7 @@ class Path {
 			if (p) p.key = index;
 		}
 		// create a Path entry for the inserted node, and regenerate the container:
-		const insertedPath = new Path(node, child.ancestors.slice(), this.ctx);
 		child._regenerateParent();
-		this._regenerateParent();
 	}
 
 	_regenerate() {

--- a/packages/wmr/src/lib/acorn-traverse.js
+++ b/packages/wmr/src/lib/acorn-traverse.js
@@ -318,7 +318,7 @@ class Path {
 				ancestors.push(prev);
 			}
 		}
-		return new Path(node, ancestors, this.ctx);
+		return Array.isArray(node) ? node.map(x => new Path(x, ancestors, this.ctx)) : new Path(node, ancestors, this.ctx);
 	}
 
 	/** @param {Path | Node} node */
@@ -364,6 +364,10 @@ class Path {
 	/** @param {string} str */
 	appendString(str) {
 		this.ctx.out.appendRight(this.end, str);
+	}
+
+	insertAfter(node) {
+		// TODO: implement
 	}
 
 	_regenerate() {

--- a/packages/wmr/src/lib/acorn-traverse.js
+++ b/packages/wmr/src/lib/acorn-traverse.js
@@ -178,6 +178,7 @@ for (let type in codeGenerator) {
 				} catch (e) {}
 			}
 		}
+
 		fn.call(this, node, state);
 	};
 }
@@ -429,6 +430,7 @@ const TYPES = {
 		}
 		return clone;
 	},
+	variableDeclarator: id => ({ type: 'VariableDeclarator', id }),
 	identifier: name => ({ type: 'Identifier', name }),
 	stringLiteral: value => ({ type: 'StringLiteral', value }),
 	booleanLiteral: value => ({ type: 'BooleanLiteral', value }),

--- a/packages/wmr/src/lib/transform-jsx-to-htm-lite.js
+++ b/packages/wmr/src/lib/transform-jsx-to-htm-lite.js
@@ -37,7 +37,11 @@ export default function transformJsxToHtmLite({ types: t }, options = {}) {
 						const lib = typeof tagImport === 'string' ? tagImport : tagImport.module;
 						let imp = (typeof tagImport === 'object' && tagImport.export) || tagString;
 						if (tagString !== imp) imp += ' as ' + tagString;
-						path.get('body').prependString(`import { ${imp} } from '${lib}';\n`);
+
+						path.unshiftContainer(
+							'body',
+							t.importDeclaration([t.importSpecifier(t.identifier(imp), t.identifier(imp))], t.stringLiteral(lib))
+						);
 					}
 				}
 			},

--- a/packages/wmr/src/lib/transform-prefresh-registrations.js
+++ b/packages/wmr/src/lib/transform-prefresh-registrations.js
@@ -1,0 +1,475 @@
+function hash(str) {
+	let hash = 5381,
+		i = str.length;
+	while (i) {
+		hash = (hash * 33) ^ str.charCodeAt(--i);
+	}
+
+	return (hash >>> 0).toString(36);
+}
+
+export default function transformPrefreshRegistrations({ types: t, template }, options = {}) {
+	const refreshReg = t.identifier('$RefreshReg$');
+
+	const registrationsByProgramPath = new Map();
+	const seenForRegistration = new WeakSet();
+	const seenForOutro = new WeakSet();
+
+	const isComponentishName = name => typeof name === 'string' && name[0] >= 'A' && name[0] <= 'Z';
+
+	function createRegistration(programPath, persistentID) {
+		const handle = programPath.scope.generateUidIdentifier('c');
+		console.log('registering', programPath, persistentID);
+		if (!registrationsByProgramPath.has(programPath)) {
+			registrationsByProgramPath.set(programPath, []);
+		}
+
+		const registrations = registrationsByProgramPath.get(programPath);
+		registrations.push({
+			handle,
+			persistentID
+		});
+
+		return handle;
+	}
+
+	function findInnerComponents(inferredName, path, callback) {
+		const node = path.node;
+		switch (node.type) {
+			case 'Identifier': {
+				if (!isComponentishName(node.name)) {
+					return false;
+				}
+				// export default hoc(Foo)
+				// const X = hoc(Foo)
+				callback(inferredName, node, null);
+				return true;
+			}
+			case 'FunctionDeclaration': {
+				// function Foo() {}
+				// export function Foo() {}
+				// export default function Foo() {}
+				callback(inferredName, node.id, null);
+				return true;
+			}
+			case 'ArrowFunctionExpression': {
+				if (node.body.type === 'ArrowFunctionExpression') {
+					return false;
+				}
+				// let Foo = () => {}
+				// export default hoc1(hoc2(() => {}))
+				callback(inferredName, node, path);
+				return true;
+			}
+			case 'FunctionExpression': {
+				// let Foo = function() {}
+				// const Foo = hoc1(forwardRef(function renderFoo() {}))
+				// export default memo(function() {})
+				callback(inferredName, node, path);
+				return true;
+			}
+			case 'CallExpression': {
+				const argsPath = path.get('arguments');
+				if (argsPath === undefined || argsPath.length === 0) {
+					return false;
+				}
+				const calleePath = path.get('callee');
+				switch (calleePath.node.type) {
+					case 'MemberExpression':
+					case 'Identifier': {
+						const calleeSource = calleePath.getSource();
+						const firstArgPath = argsPath[0];
+						const innerName = inferredName + '$' + calleeSource;
+						const foundInside = findInnerComponents(innerName, firstArgPath, callback);
+						if (!foundInside) {
+							return false;
+						}
+						// const Foo = hoc1(hoc2(() => {}))
+						// export default memo(React.forwardRef(function() {}))
+						callback(inferredName, node, path);
+						return true;
+					}
+					default: {
+						return false;
+					}
+				}
+			}
+			case 'VariableDeclarator': {
+				const init = node.init;
+				if (init === null) {
+					return false;
+				}
+				const name = node.id.name;
+				if (!isComponentishName(name)) {
+					return false;
+				}
+				switch (init.type) {
+					case 'ArrowFunctionExpression':
+					case 'FunctionExpression':
+						// Likely component definitions.
+						break;
+					case 'CallExpression': {
+						// Maybe a HOC.
+						// Try to determine if this is some form of import.
+						const callee = init.callee;
+						const calleeType = callee.type;
+						if (calleeType === 'Import') {
+							return false;
+						} else if (calleeType === 'Identifier') {
+							if (callee.name.indexOf('require') === 0) {
+								return false;
+							} else if (callee.name.indexOf('import') === 0) {
+								return false;
+							}
+							// Neither require nor import. Might be a HOC.
+							// Pass through.
+						} else if (calleeType === 'MemberExpression') {
+							// Could be something like React.forwardRef(...)
+							// Pass through.
+						}
+						break;
+					}
+					case 'TaggedTemplateExpression':
+						// Maybe something like styled.div`...`
+						break;
+					default:
+						return false;
+				}
+				const initPath = path.get('init');
+				const foundInside = findInnerComponents(inferredName, initPath, callback);
+				if (foundInside) {
+					return true;
+				}
+				// See if this identifier is used in JSX. Then it's a component.
+				const binding = path.scope.getBinding(name);
+				if (binding === undefined) {
+					return;
+				}
+				let isLikelyUsedAsType = false;
+				const referencePaths = binding.referencePaths;
+				for (let i = 0; i < referencePaths.length; i++) {
+					const ref = referencePaths[i];
+					if (ref.node && ref.node.type !== 'JSXIdentifier' && ref.node.type !== 'Identifier') {
+						continue;
+					}
+					const refParent = ref.parent;
+					if (refParent.type === 'JSXOpeningElement') {
+						isLikelyUsedAsType = true;
+					} else if (refParent.type === 'CallExpression') {
+						const callee = refParent.callee;
+						let fnName;
+						switch (callee.type) {
+							case 'Identifier':
+								fnName = callee.name;
+								break;
+							case 'MemberExpression':
+								fnName = callee.property.name;
+								break;
+						}
+						switch (fnName) {
+							case 'createElement':
+							case 'jsx':
+							case 'jsxDEV':
+							case 'jsxs':
+								isLikelyUsedAsType = true;
+								break;
+						}
+					}
+					if (isLikelyUsedAsType) {
+						// const X = ... + later <X />
+						callback(inferredName, init, initPath);
+						return true;
+					}
+				}
+			}
+		}
+		return false;
+	}
+
+	const createContextTemplate = template(
+		`
+    Object.assign((CREATECONTEXT.IDENT || (CREATECONTEXT.IDENT=CREATECONTEXT(VALUE))), {__:VALUE});
+  `,
+		{ placeholderPattern: /^[A-Z]+$/ }
+	);
+
+	const emptyTemplate = template(`
+    (CREATECONTEXT.IDENT || (CREATECONTEXT.IDENT=CREATECONTEXT()));
+	`);
+
+	const getFirstNonTsExpression = expression =>
+		expression.type === 'TSAsExpression' ? getFirstNonTsExpression(expression.expression) : expression;
+
+	return {
+		name: 'transform-prefresh-registrations',
+		visitor: {
+			ClassDeclaration: {
+				enter(path) {
+					const node = path.node;
+					let programPath;
+					let insertAfterPath;
+					switch (path.parent.type) {
+						case 'Program':
+							insertAfterPath = path;
+							programPath = path.parentPath;
+							break;
+						case 'ExportNamedDeclaration':
+							insertAfterPath = path.parentPath;
+							programPath = insertAfterPath.parentPath;
+							break;
+						case 'ExportDefaultDeclaration':
+							insertAfterPath = path.parentPath;
+							programPath = insertAfterPath.parentPath;
+							break;
+						default:
+							return;
+					}
+					const id = node.id;
+					if (id === null) {
+						// We don't currently handle anonymous default exports.
+						return;
+					}
+					const inferredName = id.name;
+					if (!isComponentishName(inferredName)) {
+						return;
+					}
+
+					// Make sure we're not mutating the same tree twice.
+					// This can happen if another Babel plugin replaces parents.
+					if (seenForRegistration.has(node)) {
+						return;
+					}
+					seenForRegistration.add(node);
+					// Don't mutate the tree above this point.
+
+					const handle = createRegistration(programPath, inferredName);
+					insertAfterPath.insertAfter(t.expressionStatement(t.assignmentExpression('=', handle, path.node.id)));
+				}
+			},
+			CallExpression(path, state) {
+				if (!path.get('callee').referencesImport('preact', 'createContext')) return;
+
+				let id = '';
+				if (t.isVariableDeclarator(path.parentPath)) {
+					id += '$' + path.parent.id.name;
+				} else if (t.isAssignmentExpression(path.parentPath)) {
+					if (t.isIdentifier(path.parent.left)) {
+						id += '_' + path.parent.left.name;
+					} else {
+						id += '_' + hash(path.parentPath.get('left').getSource());
+					}
+				}
+				const contexts = state.get('contexts');
+				let counter = (contexts.get(id) || -1) + 1;
+				contexts.set(id, counter);
+				if (counter) id += counter;
+				id = '_' + state.get('filehash') + id;
+				path.skip();
+				if (path.node.arguments[0]) {
+					path.replaceWith(
+						createContextTemplate({
+							CREATECONTEXT: path.get('callee').node,
+							IDENT: t.identifier(id),
+							VALUE: t.clone(getFirstNonTsExpression(path.node.arguments[0]))
+						})
+					);
+				} else {
+					path.replaceWith(
+						emptyTemplate({
+							CREATECONTEXT: path.get('callee').node,
+							IDENT: t.identifier(id)
+						})
+					);
+				}
+			},
+			ExportDefaultDeclaration(path) {
+				const node = path.node;
+				const decl = node.declaration;
+				const declPath = path.get('declaration');
+				if (decl.type !== 'CallExpression') {
+					// For now, we only support possible HOC calls here.
+					// Named function declarations are handled in FunctionDeclaration.
+					// Anonymous direct exports like export default function() {}
+					// are currently ignored.
+					return;
+				}
+
+				// Make sure we're not mutating the same tree twice.
+				// This can happen if another Babel plugin replaces parents.
+				if (seenForRegistration.has(node)) {
+					return;
+				}
+				seenForRegistration.add(node);
+				// Don't mutate the tree above this point.
+
+				// This code path handles nested cases like:
+				// export default memo(() => {})
+				// In those cases it is more plausible people will omit names
+				// so they're worth handling despite possible false positives.
+				// More importantly, it handles the named case:
+				// export default memo(function Named() {})
+				const inferredName = '%default%';
+				const programPath = path.parentPath;
+				findInnerComponents(inferredName, declPath, (persistentID, targetExpr, targetPath) => {
+					if (targetPath === null) {
+						// For case like:
+						// export default hoc(Foo)
+						// we don't want to wrap Foo inside the call.
+						// Instead we assume it's registered at definition.
+						return;
+					}
+					const handle = createRegistration(programPath, persistentID);
+					targetPath.replaceWith(t.assignmentExpression('=', handle, targetExpr));
+				});
+			},
+			FunctionDeclaration: {
+				enter(path) {
+					const node = path.node;
+					let programPath;
+					let insertAfterPath;
+					switch (path.parent.type) {
+						case 'Program':
+							insertAfterPath = path;
+							programPath = path.parentPath;
+							break;
+						case 'ExportNamedDeclaration':
+							insertAfterPath = path.parentPath;
+							programPath = insertAfterPath.parentPath;
+							break;
+						case 'ExportDefaultDeclaration':
+							insertAfterPath = path.parentPath;
+							programPath = insertAfterPath.parentPath;
+							break;
+						default:
+							return;
+					}
+					const id = node.id;
+					if (id === null) {
+						// We don't currently handle anonymous default exports.
+						return;
+					}
+					const inferredName = id.name;
+					if (!isComponentishName(inferredName)) {
+						return;
+					}
+
+					// Make sure we're not mutating the same tree twice.
+					// This can happen if another Babel plugin replaces parents.
+					if (seenForRegistration.has(node)) {
+						return;
+					}
+					seenForRegistration.add(node);
+					// Don't mutate the tree above this point.
+
+					// export function Named() {}
+					// function Named() {}
+					findInnerComponents(inferredName, path, (persistentID, targetExpr) => {
+						const handle = createRegistration(programPath, persistentID);
+						insertAfterPath.insertAfter(t.expressionStatement(t.assignmentExpression('=', handle, targetExpr)));
+					});
+				}
+			},
+			VariableDeclaration(path) {
+				const node = path.node;
+				let programPath;
+				let insertAfterPath;
+
+				switch (path.parent.type) {
+					case 'Program':
+						insertAfterPath = path;
+						programPath = path.parentPath;
+						break;
+					case 'ExportNamedDeclaration':
+						insertAfterPath = path.parentPath;
+						programPath = insertAfterPath.parentPath;
+						break;
+					case 'ExportDefaultDeclaration':
+						insertAfterPath = path.parentPath;
+						programPath = insertAfterPath.parentPath;
+						break;
+					default:
+						return;
+				}
+
+				// Make sure we're not mutating the same tree twice.
+				// This can happen if another Babel plugin replaces parents.
+				if (seenForRegistration.has(node)) {
+					return;
+				}
+				seenForRegistration.add(node);
+				// Don't mutate the tree above this point.
+
+				const declPaths = path.get('declarations');
+
+				// TODO: in babel this is just declPaths.length
+				if (declPaths.node.length !== 1) {
+					return;
+				}
+
+				// TODO: to make this work the declPath should be an actual path, where we can get, ...
+				const declPath = declPaths.node[0];
+				const inferredName = declPath.id.name;
+				findInnerComponents(inferredName, declPath, (persistentID, targetExpr, targetPath) => {
+					if (targetPath === null) {
+						// For case like:
+						// export const Something = hoc(Foo)
+						// we don't want to wrap Foo inside the call.
+						// Instead we assume it's registered at definition.
+						return;
+					}
+					const handle = createRegistration(programPath, persistentID);
+					if (targetPath.parent.type === 'VariableDeclarator') {
+						// Special case when a variable would get an inferred name:
+						// let Foo = () => {}
+						// let Foo = function() {}
+						// let Foo = styled.div``;
+						// We'll register it on next line so that
+						// we don't mess up the inferred 'Foo' function name.
+						// (eg: with @babel/plugin-transform-react-display-name or
+						// babel-plugin-styled-components)
+						insertAfterPath.insertAfter(t.expressionStatement(t.assignmentExpression('=', handle, declPath.node.id)));
+						// Result: let Foo = () => {}; _c1 = Foo;
+					} else {
+						// let Foo = hoc(() => {})
+						targetPath.replaceWith(t.assignmentExpression('=', handle, targetExpr));
+						// Result: let Foo = hoc(_c1 = () => {})
+					}
+				});
+			},
+			Program: {
+				enter(path, state) {
+					// TODO: no fileHash
+					state.set('filehash', hash(/*path.hub.file.opts.filename || */ 'unnamed'));
+					state.set('contexts', new Map());
+				},
+				exit(path) {
+					const registrations = registrationsByProgramPath.get(path);
+					console.log(registrationsByProgramPath);
+					if (registrations === undefined) {
+						return;
+					}
+
+					// Make sure we're not mutating the same tree twice.
+					// This can happen if another Babel plugin replaces parents.
+					const node = path.node;
+					if (seenForOutro.has(node)) {
+						return;
+					}
+					seenForOutro.add(node);
+					// Don't mutate the tree above this point.
+
+					registrationsByProgramPath.delete(path);
+					const declarators = [];
+					path.pushContainer('body', t.variableDeclaration('var', declarators));
+					registrations.forEach(({ handle, persistentID }) => {
+						path.pushContainer(
+							'body',
+							t.expressionStatement(t.callExpression(refreshReg, [handle, t.stringLiteral(persistentID)]))
+						);
+						declarators.push(t.variableDeclarator(handle));
+					});
+				}
+			}
+		}
+	};
+}

--- a/packages/wmr/src/lib/transform-prefresh-registrations.js
+++ b/packages/wmr/src/lib/transform-prefresh-registrations.js
@@ -413,8 +413,7 @@ export default function transformPrefreshRegistrations({ types: t, template }, o
 			},
 			Program: {
 				enter(path, state) {
-					// TODO: we need the filename somewhere
-					state.set('filehash', hash(/*path.hub.file.opts.filename || */ 'unnamed'));
+					state.set('filehash', hash(path.ctx.filename || 'unnamed'));
 					state.set('contexts', new Map());
 				},
 				exit(path) {

--- a/packages/wmr/src/lib/transform-prefresh-registrations.js
+++ b/packages/wmr/src/lib/transform-prefresh-registrations.js
@@ -434,8 +434,8 @@ export default function transformPrefreshRegistrations({ types: t, template }, o
 
 					registrationsByProgramPath.delete(path);
 					const declarators = [];
+
 					// TODO: currently this crashes somewhere due to a variableDeclaration missing an array of declarations
-					path.pushContainer('body', t.variableDeclaration('var', declarators));
 					registrations.forEach(({ handle, persistentID }) => {
 						// TODO: for some reason this is added twice...
 						path.pushContainer(
@@ -445,6 +445,8 @@ export default function transformPrefreshRegistrations({ types: t, template }, o
 
 						declarators.push(t.variableDeclarator(handle));
 					});
+
+					path.unshiftContainer('body', t.variableDeclaration('var', declarators));
 				}
 			}
 		}

--- a/packages/wmr/src/lib/transform-prefresh-registrations.js
+++ b/packages/wmr/src/lib/transform-prefresh-registrations.js
@@ -434,12 +434,15 @@ export default function transformPrefreshRegistrations({ types: t, template }, o
 
 					registrationsByProgramPath.delete(path);
 					const declarators = [];
+					// TODO: currently this crashes somewhere due to a variableDeclaration missing an array of declarations
 					path.pushContainer('body', t.variableDeclaration('var', declarators));
 					registrations.forEach(({ handle, persistentID }) => {
+						// TODO: for some reason this is added twice...
 						path.pushContainer(
 							'body',
 							t.expressionStatement(t.callExpression(refreshReg, [handle, t.stringLiteral(persistentID)]))
 						);
+
 						declarators.push(t.variableDeclarator(handle));
 					});
 				}

--- a/packages/wmr/src/lib/transform-prefresh-registrations.js
+++ b/packages/wmr/src/lib/transform-prefresh-registrations.js
@@ -8,7 +8,7 @@ function hash(str) {
 	return (hash >>> 0).toString(36);
 }
 
-export default function transformPrefreshRegistrations({ types: t, template }, options = {}) {
+export default function transformPrefreshRegistrations({ types: t }, options = {}) {
 	const refreshReg = t.identifier('$RefreshReg$');
 
 	const registrationsByProgramPath = new Map();
@@ -178,19 +178,19 @@ export default function transformPrefreshRegistrations({ types: t, template }, o
 		return false;
 	}
 
-	const createContextTemplate = template(
-		`
-    Object.assign((CREATECONTEXT.IDENT || (CREATECONTEXT.IDENT=CREATECONTEXT(VALUE))), {__:VALUE});
-  `,
-		{ placeholderPattern: /^[A-Z]+$/ }
-	);
+	// const createContextTemplate = template(
+	// 	`
+	//   Object.assign((CREATECONTEXT.IDENT || (CREATECONTEXT.IDENT=CREATECONTEXT(VALUE))), {__:VALUE});
+	// `,
+	// 	{ placeholderPattern: /^[A-Z]+$/ }
+	// );
 
-	const emptyTemplate = template(`
-    (CREATECONTEXT.IDENT || (CREATECONTEXT.IDENT=CREATECONTEXT()));
-	`);
+	// const emptyTemplate = template(`
+	//   (CREATECONTEXT.IDENT || (CREATECONTEXT.IDENT=CREATECONTEXT()));
+	// `);
 
-	const getFirstNonTsExpression = expression =>
-		expression.type === 'TSAsExpression' ? getFirstNonTsExpression(expression.expression) : expression;
+	// const getFirstNonTsExpression = expression =>
+	// 	expression.type === 'TSAsExpression' ? getFirstNonTsExpression(expression.expression) : expression;
 
 	return {
 		name: 'transform-prefresh-registrations',
@@ -238,42 +238,43 @@ export default function transformPrefreshRegistrations({ types: t, template }, o
 					insertAfterPath.insertAfter(t.expressionStatement(t.assignmentExpression('=', handle, path.node.id)));
 				}
 			},
-			CallExpression(path, state) {
-				if (!path.get('callee').referencesImport('preact', 'createContext')) return;
+			// Not possible due to "referencesImport"
+			// CallExpression(path, state) {
+			// 	if (!path.get('callee').referencesImport('preact', 'createContext')) return;
 
-				let id = '';
-				if (t.isVariableDeclarator(path.parentPath)) {
-					id += '$' + path.parent.id.name;
-				} else if (t.isAssignmentExpression(path.parentPath)) {
-					if (t.isIdentifier(path.parent.left)) {
-						id += '_' + path.parent.left.name;
-					} else {
-						id += '_' + hash(path.parentPath.get('left').getSource());
-					}
-				}
-				const contexts = state.get('contexts');
-				let counter = (contexts.get(id) || -1) + 1;
-				contexts.set(id, counter);
-				if (counter) id += counter;
-				id = '_' + state.get('filehash') + id;
-				path.skip();
-				if (path.node.arguments[0]) {
-					path.replaceWith(
-						createContextTemplate({
-							CREATECONTEXT: path.get('callee').node,
-							IDENT: t.identifier(id),
-							VALUE: t.clone(getFirstNonTsExpression(path.node.arguments[0]))
-						})
-					);
-				} else {
-					path.replaceWith(
-						emptyTemplate({
-							CREATECONTEXT: path.get('callee').node,
-							IDENT: t.identifier(id)
-						})
-					);
-				}
-			},
+			// 	let id = '';
+			// 	if (t.isVariableDeclarator(path.parentPath)) {
+			// 		id += '$' + path.parent.id.name;
+			// 	} else if (t.isAssignmentExpression(path.parentPath)) {
+			// 		if (t.isIdentifier(path.parent.left)) {
+			// 			id += '_' + path.parent.left.name;
+			// 		} else {
+			// 			id += '_' + hash(path.parentPath.get('left').getSource());
+			// 		}
+			// 	}
+			// 	const contexts = state.get('contexts');
+			// 	let counter = (contexts.get(id) || -1) + 1;
+			// 	contexts.set(id, counter);
+			// 	if (counter) id += counter;
+			// 	id = '_' + state.get('filehash') + id;
+			// 	path.skip();
+			// 	if (path.node.arguments[0]) {
+			// 		path.replaceWith(
+			// 			createContextTemplate({
+			// 				CREATECONTEXT: path.get('callee').node,
+			// 				IDENT: t.identifier(id),
+			// 				VALUE: t.clone(getFirstNonTsExpression(path.node.arguments[0]))
+			// 			})
+			// 		);
+			// 	} else {
+			// 		path.replaceWith(
+			// 			emptyTemplate({
+			// 				CREATECONTEXT: path.get('callee').node,
+			// 				IDENT: t.identifier(id)
+			// 			})
+			// 		);
+			// 	}
+			// },
 			ExportDefaultDeclaration(path) {
 				const node = path.node;
 				const decl = node.declaration;

--- a/packages/wmr/src/plugins/wmr/plugin.js
+++ b/packages/wmr/src/plugins/wmr/plugin.js
@@ -1,5 +1,7 @@
 import { promises as fs } from 'fs';
 import MagicString from 'magic-string';
+import transformPrefreshRegistrations from '../../lib/transform-prefresh-registrations.js';
+import { transform } from '../../lib/acorn-traverse.js';
 import { ESM_KEYWORDS } from '../fast-cjs-plugin.js';
 
 const BYPASS_HMR = process.env.BYPASS_HMR === 'true';
@@ -73,6 +75,15 @@ export default function wmrPlugin({ hot = true, preact } = {}) {
 			// Detect modules that appear to have both JSX and an export, and inject prefresh:
 			// @todo: move to separate plugin.
 			if (code.match(/html`[^`]*<([a-zA-Z][a-zA-Z0-9.:-]*|\$\{.+?\})[^>]*>/) && hasExport && preact) {
+				code = transform(code, {
+					plugins: [transformPrefreshRegistrations],
+					filename: id,
+					sourceMaps: false,
+					generatorOpts: {
+						compact: false
+					},
+					parse: this.parse
+				}).code;
 				hasHot = true;
 				after += '\n' + PREFRESH;
 			}

--- a/packages/wmr/test/acorn-traverse.test.js
+++ b/packages/wmr/test/acorn-traverse.test.js
@@ -81,7 +81,16 @@ describe('acorn-traverse', () => {
 			const doTransform = code => transformWithPlugin(code, transformPrefreshRegistrations);
 
 			// TODO: currently wrong
-			expect(doTransform(`const Component = () => {}`)).toMatchInlineSnapshot(`"const Component = () => {}"`);
+			expect(doTransform(`const Component = () => {}`)).toMatchInlineSnapshot(`
+			"var _c0;
+			_c0 = Component;
+			_c0 = Component;
+			const Component = () => {}
+			$RefreshReg$(_c0, 'Component');
+
+			$RefreshReg$(_c0, 'Component');
+			"
+		`);
 			expect(doTransform(`const nonComponent = () => {}`)).toMatchInlineSnapshot(`"const nonComponent = () => {}"`);
 		});
 	});

--- a/packages/wmr/test/acorn-traverse.test.js
+++ b/packages/wmr/test/acorn-traverse.test.js
@@ -90,22 +90,22 @@ describe('acorn-traverse', () => {
 		`);
 			expect(doTransform(`const nonComponent = () => {}`)).toMatchInlineSnapshot(`"const nonComponent = () => {}"`);
 
-			// 	expect(
-			// 		doTransform(`
-			// 	const Component = () => {};
-			// 	const Component2 = () => {};
+			expect(
+				doTransform(`
+				const Component = () => {};
+				const Component2 = () => {};
 
-			// 	`)
-			// 	).toMatchInlineSnapshot(`
-			// 	"var _c0, _c1;
-			// 	const Component = () => {};
-			// 	_c0 = Component;
-			// 	const Component2 = () => {};
-			// 	_c1 = Component2;
-			// 	$RefreshReg$(_c0, 'Component');
-			// 	$RefreshReg$(_c1, 'Component2');
-			// 	"
-			// `);
+				`)
+			).toMatchInlineSnapshot(`
+				"var _c0, _c1;
+				const Component = () => {};
+				_c0 = Component;
+				const Component2 = () => {};
+				_c1 = Component2;
+				$RefreshReg$(_c0, 'Component');
+				$RefreshReg$(_c1, 'Component2');
+				"
+			`);
 		});
 	});
 

--- a/packages/wmr/test/acorn-traverse.test.js
+++ b/packages/wmr/test/acorn-traverse.test.js
@@ -200,36 +200,36 @@ describe('acorn-traverse', () => {
 		it('preserves exports', () => {
 			expect(
 				doTransform(`
-					export const A = forwardRef(function() {
-						return <h1>Foo</h1>;
-					});
-			`)
+						export const A = forwardRef(function() {
+							return <h1>Foo</h1>;
+						});
+				`)
 			).toMatchInlineSnapshot(`
-			"var _c0, _c1;
-			export const A = forwardRef(_c0 = function () {
-			  return <h1>Foo</h1>;
-			});
-			_c1 = A;
-			$RefreshReg$(_c0, 'A$forwardRef');
-			$RefreshReg$(_c1, 'A');
-			"
-		`);
+				"var _c0, _c1;
+				export const A = forwardRef(_c0 = function () {
+				  return <h1>Foo</h1>;
+				});
+				_c1 = A;
+				$RefreshReg$(_c0, 'A$forwardRef');
+				$RefreshReg$(_c1, 'A');
+				"
+			`);
 
 			expect(
 				doTransform(`
-				export default forwardRef(function() {
+				export default forwardRef(function () {
 					return <h1>Foo</h1>;
 				});
 		`)
 			).toMatchInlineSnapshot(`
-		"var _c0, _c1;
-		export default _c1 = forwardRef(_c0 = function () {
-			return <h1>Foo</h1>;
-		});
-		$RefreshReg$(_c0, '%default%$forwardRef');
-		$RefreshReg$(_c1, '%default%');
-		"
-	`);
+			"var _c0, _c1;
+			export default _c1 = forwardRef(_c0 = function () {
+								return <h1>Foo</h1>;
+							});
+			$RefreshReg$(_c0, '%default%$forwardRef');
+			$RefreshReg$(_c1, '%default%');
+			"
+		`);
 		});
 
 		it('registers HOCs', () => {

--- a/packages/wmr/test/acorn-traverse.test.js
+++ b/packages/wmr/test/acorn-traverse.test.js
@@ -83,11 +83,11 @@ describe('acorn-traverse', () => {
 			// TODO: currently wrong
 			expect(doTransform(`const Component = () => {}`)).toMatchInlineSnapshot(`
 			"var _c0;
-			_c0 = Component;
-			_c0 = Component;
 			const Component = () => {}
+			_c0 = Component;
 			$RefreshReg$(_c0, 'Component');
 
+			_c0 = Component;
 			$RefreshReg$(_c0, 'Component');
 			"
 		`);

--- a/packages/wmr/test/acorn-traverse.test.js
+++ b/packages/wmr/test/acorn-traverse.test.js
@@ -82,27 +82,30 @@ describe('acorn-traverse', () => {
 
 			// TODO: this var from insertAfter is missing
 			expect(doTransform(`const Component = () => {}`)).toMatchInlineSnapshot(`
-			"const Component = () => {}
+			"var _c0;
+			const Component = () => {}
 			_c0 = Component;
 			$RefreshReg$(_c0, 'Component');
 			"
 		`);
 			expect(doTransform(`const nonComponent = () => {}`)).toMatchInlineSnapshot(`"const nonComponent = () => {}"`);
 
-			expect(
-				doTransform(`
-			const Component = () => {};
-			const Component2 = () => {};
+			// 	expect(
+			// 		doTransform(`
+			// 	const Component = () => {};
+			// 	const Component2 = () => {};
 
-			`)
-			).toMatchInlineSnapshot(`
-			"const Component = () => {};
-			_c0 = Component;
-			const Component2 = () => {};
-			_c1 = Component2;
-			$RefreshReg$(_c0, 'Component');
-			"
-		`);
+			// 	`)
+			// 	).toMatchInlineSnapshot(`
+			// 	"var _c0, _c1;
+			// 	const Component = () => {};
+			// 	_c0 = Component;
+			// 	const Component2 = () => {};
+			// 	_c1 = Component2;
+			// 	$RefreshReg$(_c0, 'Component');
+			// 	$RefreshReg$(_c1, 'Component2');
+			// 	"
+			// `);
 		});
 	});
 

--- a/packages/wmr/test/acorn-traverse.test.js
+++ b/packages/wmr/test/acorn-traverse.test.js
@@ -205,15 +205,15 @@ describe('acorn-traverse', () => {
 						});
 				`)
 			).toMatchInlineSnapshot(`
-				"var _c0, _c1;
-				export const A = forwardRef(_c0 = function () {
-				  return <h1>Foo</h1>;
-				});
-				_c1 = A;
-				$RefreshReg$(_c0, 'A$forwardRef');
-				$RefreshReg$(_c1, 'A');
-				"
-			`);
+			"var _c0, _c1;
+			export const A = forwardRef(_c0 = function() {
+										return <h1>Foo</h1>;
+									});
+			_c1 = A;
+			$RefreshReg$(_c0, 'A$forwardRef');
+			$RefreshReg$(_c1, 'A');
+			"
+		`);
 
 			expect(
 				doTransform(`
@@ -247,13 +247,13 @@ describe('acorn-traverse', () => {
 			`)
 			).toMatchInlineSnapshot(`
 			"var _c0, _c1, _c2, _c3, _c4, _c5, _c6, _c7;
-			const A = forwardRef(_c0 = function () {
-			  return <h1>Foo</h1>;
-			});
+			const A = forwardRef(_c0 = function() {
+									return <h1>Foo</h1>;
+								});
 			_c1 = A;
 			const B = memo(_c3 = forwardRef(_c2 = () => {
-			  return <h1>Foo</h1>;
-			}));
+									return <h1>Foo</h1>;
+								}));
 			_c4 = B;
 			export default _c7 = memo(_c6 = forwardRef(_c5 = (props, ref) => {
 									return <h1>Foo</h1>;

--- a/packages/wmr/test/acorn-traverse.test.js
+++ b/packages/wmr/test/acorn-traverse.test.js
@@ -197,6 +197,41 @@ describe('acorn-traverse', () => {
 		`);
 		});
 
+		it('preserves exports', () => {
+			expect(
+				doTransform(`
+					export const A = forwardRef(function() {
+						return <h1>Foo</h1>;
+					});
+			`)
+			).toMatchInlineSnapshot(`
+			"var _c0, _c1;
+			export const A = forwardRef(_c0 = function () {
+			  return <h1>Foo</h1>;
+			});
+			_c1 = A;
+			$RefreshReg$(_c0, 'A$forwardRef');
+			$RefreshReg$(_c1, 'A');
+			"
+		`);
+
+			expect(
+				doTransform(`
+				export default forwardRef(function() {
+					return <h1>Foo</h1>;
+				});
+		`)
+			).toMatchInlineSnapshot(`
+		"var _c0, _c1;
+		export default _c1 = forwardRef(_c0 = function () {
+			return <h1>Foo</h1>;
+		});
+		$RefreshReg$(_c0, '%default%$forwardRef');
+		$RefreshReg$(_c1, '%default%');
+		"
+	`);
+		});
+
 		it('registers HOCs', () => {
 			expect(
 				doTransform(`
@@ -212,18 +247,19 @@ describe('acorn-traverse', () => {
 			`)
 			).toMatchInlineSnapshot(`
 			"var _c0, _c1, _c2, _c3, _c4, _c5, _c6, _c7;
-			const A = forwardRef(function () {
+			const A = forwardRef(_c0 = function () {
 			  return <h1>Foo</h1>;
 			});
 			_c1 = A;
-			_c0 = A;
-			const B = memo(forwardRef(() => {
+			const B = memo(_c3 = forwardRef(_c2 = () => {
 			  return <h1>Foo</h1>;
 			}));
 			_c4 = B;
-			_c3 = B;
-			_c2 = B;
-			export default _c7 = ;
+
+			export default _c7 = React.memo(_c6 = forwardRef(_c5 = (props, ref) => {
+				return <h1>Foo</h1>;
+			}));
+
 			$RefreshReg$(_c0, 'A$forwardRef');
 			$RefreshReg$(_c1, 'A');
 			$RefreshReg$(_c2, 'B$memo$forwardRef');
@@ -232,34 +268,6 @@ describe('acorn-traverse', () => {
 			$RefreshReg$(_c5, '%default%$memo$forwardRef');
 			$RefreshReg$(_c6, '%default%$memo');
 			$RefreshReg$(_c7, '%default%');
-			"
-		`);
-			expect(
-				doTransform(`
-					export default memo(forwardRef(function (props, ref) {
-						return <h1>Foo</h1>;
-					}));
-			`)
-			).toMatchInlineSnapshot(`
-			"var _c0, _c1, _c2;
-			export default _c2 = ;
-			$RefreshReg$(_c0, '%default%$memo$forwardRef');
-			$RefreshReg$(_c1, '%default%$memo');
-			$RefreshReg$(_c2, '%default%');
-			"
-		`);
-			expect(
-				doTransform(`
-					export default memo(forwardRef(function Named(props, ref) {
-						return <h1>Foo</h1>;
-					}));
-			`)
-			).toMatchInlineSnapshot(`
-			"var _c0, _c1, _c2;
-			export default _c2 = ;
-			$RefreshReg$(_c0, '%default%$memo$forwardRef');
-			$RefreshReg$(_c1, '%default%$memo');
-			$RefreshReg$(_c2, '%default%');
 			"
 		`);
 		});

--- a/packages/wmr/test/acorn-traverse.test.js
+++ b/packages/wmr/test/acorn-traverse.test.js
@@ -255,11 +255,9 @@ describe('acorn-traverse', () => {
 			  return <h1>Foo</h1>;
 			}));
 			_c4 = B;
-
-			export default _c7 = React.memo(_c6 = forwardRef(_c5 = (props, ref) => {
-				return <h1>Foo</h1>;
-			}));
-
+			export default _c7 = memo(_c6 = forwardRef(_c5 = (props, ref) => {
+									return <h1>Foo</h1>;
+								}));
 			$RefreshReg$(_c0, 'A$forwardRef');
 			$RefreshReg$(_c1, 'A');
 			$RefreshReg$(_c2, 'B$memo$forwardRef');

--- a/packages/wmr/test/acorn-traverse.test.js
+++ b/packages/wmr/test/acorn-traverse.test.js
@@ -25,6 +25,7 @@ function transformWithPlugin(code, plugin, options = {}) {
 	return transform(code, {
 		parse,
 		plugins: [plugin],
+		filename: 'test.jsx',
 		...options
 	}).code;
 }

--- a/packages/wmr/test/acorn-traverse.test.js
+++ b/packages/wmr/test/acorn-traverse.test.js
@@ -5,6 +5,7 @@ import * as acorn from 'acorn';
 import acornJsx from 'acorn-jsx';
 import { transform, generate } from '../src/lib/acorn-traverse.js';
 import transformJsxToHtm from 'babel-plugin-transform-jsx-to-htm';
+import transformPrefreshRegistrations from '../src/lib/transform-prefresh-registrations.js';
 // import transformJsxToHtmLite from '../src/lib/transform-jsx-to-htm-lite.js';
 
 const fixtures = path.join(__dirname, 'fixtures/_unit');
@@ -71,6 +72,16 @@ describe('acorn-traverse', () => {
 			expect(transform('html`${x.map(([a,b,c]) => ({a,b,c}))}`;')).toMatchInlineSnapshot(
 				`"$tag(html)\`\${x.map(([a,b,c]) => ({a,b,c}))}\`;"`
 			);
+		});
+	});
+
+	describe('prefresh-registrations', () => {
+		it('should generate signatures for Prefresh', () => {
+			const doTransform = code => transformWithPlugin(code, transformPrefreshRegistrations);
+
+			// TODO: currently wrong
+			expect(doTransform(`const Component = () => {}`)).toMatchInlineSnapshot(`"const Component = () => {}"`);
+			expect(doTransform(`const nonComponent = () => {}`)).toMatchInlineSnapshot(`"const nonComponent = () => {}"`);
 		});
 	});
 

--- a/packages/wmr/test/acorn-traverse.test.js
+++ b/packages/wmr/test/acorn-traverse.test.js
@@ -80,18 +80,29 @@ describe('acorn-traverse', () => {
 		it('should generate signatures for Prefresh', () => {
 			const doTransform = code => transformWithPlugin(code, transformPrefreshRegistrations);
 
-			// TODO: currently wrong
+			// TODO: this var from insertAfter is missing
 			expect(doTransform(`const Component = () => {}`)).toMatchInlineSnapshot(`
-			"var _c0;
-			const Component = () => {}
-			_c0 = Component;
-			$RefreshReg$(_c0, 'Component');
-
+			"const Component = () => {}
 			_c0 = Component;
 			$RefreshReg$(_c0, 'Component');
 			"
 		`);
 			expect(doTransform(`const nonComponent = () => {}`)).toMatchInlineSnapshot(`"const nonComponent = () => {}"`);
+
+			expect(
+				doTransform(`
+			const Component = () => {};
+			const Component2 = () => {};
+
+			`)
+			).toMatchInlineSnapshot(`
+			"const Component = () => {};
+			_c0 = Component;
+			const Component2 = () => {};
+			_c1 = Component2;
+			$RefreshReg$(_c0, 'Component');
+			"
+		`);
 		});
 	});
 

--- a/packages/wmr/test/acorn-traverse.test.js
+++ b/packages/wmr/test/acorn-traverse.test.js
@@ -83,7 +83,7 @@ describe('acorn-traverse', () => {
 			// TODO: this var from insertAfter is missing
 			expect(doTransform(`const Component = () => {}`)).toMatchInlineSnapshot(`
 			"var _c0;
-			const Component = () => {}
+			const Component = () => {};
 			_c0 = Component;
 			$RefreshReg$(_c0, 'Component');
 			"

--- a/packages/wmr/test/fixtures/hmr/home.js
+++ b/packages/wmr/test/fixtures/hmr/home.js
@@ -1,14 +1,22 @@
 import useCounter from './useCounter.js';
 
-function Home() {
+function Counter() {
 	const [count, increment] = useCounter();
 	return (
-		<div>
-			<p class="home">Home</p>
+		<>
 			<p class="count">{count}</p>
 			<p class="increment" onClick={increment}>
 				Increment
 			</p>
+		</>
+	);
+}
+
+function Home() {
+	return (
+		<div>
+			<p class="home">Home</p>
+			<Counter />
 		</div>
 	);
 }

--- a/packages/wmr/test/fixtures/transformations/jsx-escaped.expected.js
+++ b/packages/wmr/test/fixtures/transformations/jsx-escaped.expected.js
@@ -1,4 +1,7 @@
+var _c0;
 import { html as $$html } from '/@npm/htm/preact';
 export function Foo() {
 	return $$html`<span>${`<`}</span>`;
 }
+_c0 = Foo;
+$RefreshReg$(_c0, 'Foo');

--- a/packages/wmr/test/fixtures/transformations/jsx-member.expected.js
+++ b/packages/wmr/test/fixtures/transformations/jsx-member.expected.js
@@ -1,3 +1,4 @@
+var _c0;
 import { html as $$html } from '/@npm/htm/preact';
 const Ctx = {
 	Foo: function Foo() {
@@ -12,3 +13,5 @@ export default function Demo() {
 		<//>`
 	);
 }
+_c0 = Demo;
+$RefreshReg$(_c0, 'Demo');

--- a/packages/wmr/test/fixtures/transformations/jsx-self-closed.expected.js
+++ b/packages/wmr/test/fixtures/transformations/jsx-self-closed.expected.js
@@ -1,8 +1,14 @@
+var _c0, _c1, _c2;
 import { html as $$html } from '/@npm/htm/preact';
 const Bar = () => null;
+_c0 = Bar;
 const Bob = () => null;
-
+_c1 = Bob;
 export function Foo() {
 	// prettier-ignore
 	return $$html`<${Bar}><${Bob} /><//>`;
 }
+_c2 = Foo;
+$RefreshReg$(_c0, 'Bar');
+$RefreshReg$(_c1, 'Bob');
+$RefreshReg$(_c2, 'Foo');

--- a/packages/wmr/test/fixtures/transformations/jsx.expected.js
+++ b/packages/wmr/test/fixtures/transformations/jsx.expected.js
@@ -1,3 +1,4 @@
+var _c0;
 import { html as $$html } from '/@npm/htm/preact';
 const LIST = [
 	{ id: 'one', text: 'item 1', props: {} },
@@ -26,3 +27,5 @@ export default function Demo({ name = 'Bob', list = LIST }) {
 		</div>`
 	);
 }
+_c0 = Demo;
+$RefreshReg$(_c0, 'Demo');


### PR DESCRIPTION
Currently finding incompatibilities with `acorn-traverse` currently this does not calculate any signatures for hooks yet because of the complexity it would introduce within acorn-traverse, this can be a gradual process.

Adding registrations allows us to hot-reload and detect components that aren't exported,...

An alternative would be to wait for https://github.com/swc-project/swc/pull/1077