### PR TITLE
(wmr) Fix double quotes imports with bundle-plugin

### DIFF
--- a/.changeset/hot-squids-learn.md
+++ b/.changeset/hot-squids-learn.md
@@ -1,0 +1,5 @@
+---
+'wmr': patch
+---
+
+Fix double quotes imports with bundle-plugin

--- a/packages/wmr/src/plugins/bundle-plugin.js
+++ b/packages/wmr/src/plugins/bundle-plugin.js
@@ -16,7 +16,7 @@ export default function bundlePlugin({ cwd = '.', inline } = {}) {
 				if (inline) {
 					const url = '/' + relative(cwd, resolved.id).replace(/^\./, '');
 					return {
-						id: `data:text/javascript,export default${JSON.stringify(url)}`.replace(/#/g, '%23'),
+						id: `data:text/javascript,export default${encodeURIComponent(JSON.stringify(url))}`,
 						external: true
 					};
 				}


### PR DESCRIPTION
JavaScript imports can use either single or double quotes:

```js
import 'bundle:./file';
import "bundle:./file";
```

Currently, when using double quotes, the import fail because it's being translated to:

```js
import "data:text/javascript,export default"./file""
```

With this PR, it'll be translated to:

```js
import "data:text/javascript,export default%22./file%22"
```