### PR TITLE
(preact-iso): Use history.replaceState for route function

### DIFF
--- a/packages/preact-iso/router.js
+++ b/packages/preact-iso/router.js
@@ -1,7 +1,11 @@
 import { h, createContext, cloneElement } from 'preact';
 import { useContext, useMemo, useReducer, useEffect, useLayoutEffect, useRef } from 'preact/hooks';
 
-const UPDATE = (state, url, push) => {
+const UPDATE = (state, url) => {
+	/** @type {boolean|undefined} - History state update strategy */
+	let push = undefined
+
+	// user click (Mouse event)
 	if (url && url.type === 'click') {
 		const link = url.target.closest('a[href]');
 		if (!link || link.origin != location.origin) return state;
@@ -9,8 +13,12 @@ const UPDATE = (state, url, push) => {
 		url.preventDefault();
 		push = true;
 		url = link.href.replace(location.origin, '');
+	// navigation (PopStateEvent)
 	} else if (typeof url !== 'string') {
 		url = location.pathname + location.search;
+	// manual invocation (useLocation().route)
+	} else {
+		push = false
 	}
 
 	if (push === true) history.pushState(null, '', url);


### PR DESCRIPTION
Do not merge yet, work in progress

At this moment when using `useLocation().route('/foobar')` in the effect either `history.pushState` nor `history.replaceState` method is used and window location doesn't change.

This pull request changes it's behavior in that window location will be replaced.

It would be more convenient to choose desired action like in [preact/router](https://github.com/preactjs/preact-router#redirects):

```js
function route(url, replace=false)
```

and probably this what the `push` argument in https://github.com/preactjs/wmr/blob/58f1bffd108f45c1ac5759f744f484b5d6a8fcca/packages/preact-iso/router.js#L4 was meant for, however as the useReducer dispatcher accepts only two arguments, it's value cannot be set and in effect defaults to 
 `undefined` and may be set to `true` when invoked via `MouseEvent.

One way to solve it is to rewrite dispatcher is it would be possible to call `useLocation().route()` with following signatures:

```js
// Use history.pushState
route('/foobar);
route({ path: '/foobar', replace: false});

// Use history.replaceState
route({ path: '/foobar', replace: true});
```