### PR TITLE
ci: Fixing actions on PRs with better pathing tool

### DIFF
--- a/.github/workflows/compressed-size.yml
+++ b/.github/workflows/compressed-size.yml
@@ -1,10 +1,8 @@
 name: compressed-size
 on:
   pull_request:
-    branches: 
+    branches:
       - main
-    paths:
-      - packages/wmr/**
 
 jobs:
   build:
@@ -12,7 +10,15 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            wmr:
+              - 'packages/wmr/**'
+
       - name: compressed-size-action
+        if: ${{ steps.filter.outputs.wmr == 'true' }}
         uses: preactjs/compressed-size-action@v2
         with:
           pattern: 'packages/wmr/{wmr.cjs,demo/dist/**/*.{js,css,html}}'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,16 +4,30 @@ on:
   push:
     branches:
       - main
-    paths:
-      - packages/wmr/**
-      - packages/preact-iso/**
   pull_request:
-    paths:
-      - packages/wmr/**
-      - packages/preact-iso/**
+    branches:
+      - main
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      wmr: ${{ steps.filter.outputs.wmr }}
+      preact-iso: ${{ steps.filter.outputs.preact-iso }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            wmr:
+              - 'packages/wmr/**'
+            preact-iso:
+              - 'packages/preact-iso/**'
+
   build:
+    needs: changes
+    if: ${{ needs.changes.outputs.wmr == 'true' || needs.changes.outputs.preact-iso == 'true' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -29,13 +43,18 @@ jobs:
       - name: Install
         run: yarn --frozen-lockfile
       - name: Build
+        if: ${{ needs.changes.outputs.wmr == 'true' }}
         run: yarn workspace wmr build
       - name: Test wmr
+        if: ${{ needs.changes.outputs.wmr == 'true' }}
         run: yarn workspace wmr test
       - name: Test preact-iso
+        if: ${{ needs.changes.outputs.preact-iso == 'true' }}
         run: yarn workspace preact-iso test
 
   lhci:
+    needs: changes
+    if: ${{ needs.changes.outputs.wmr == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,6 @@ jobs:
 
   build:
     needs: changes
-    if: ${{ needs.changes.outputs.wmr == 'true' || needs.changes.outputs.preact-iso == 'true' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -41,6 +40,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install
+        if: ${{ needs.changes.outputs.wmr == 'true' || needs.changes.outputs.preact-iso == 'true' }}
         run: yarn --frozen-lockfile
       - name: Build
         if: ${{ needs.changes.outputs.wmr == 'true' }}


### PR DESCRIPTION
This should fix the issue of actions being required on PRs but never running due to the paths

Seems to be a decent action, does what it says on the tin: https://github.com/dorny/paths-filter