### PR TITLE
(preact-iso): Router: Fix change location after useLocation().route()

### DIFF
--- a/.changeset/sharp-cats-relate.md
+++ b/.changeset/sharp-cats-relate.md
@@ -1,0 +1,5 @@
+---
+'preact-iso': patch
+---
+
+Set default value for push to true

--- a/packages/preact-iso/router.js
+++ b/packages/preact-iso/router.js
@@ -1,16 +1,17 @@
 import { h, createContext, cloneElement } from 'preact';
 import { useContext, useMemo, useReducer, useEffect, useLayoutEffect, useRef } from 'preact/hooks';
 
-const UPDATE = (state, url, push) => {
+const UPDATE = (state, url) => {
+	let push = true;
 	if (url && url.type === 'click') {
 		const link = url.target.closest('a[href]');
 		if (!link || link.origin != location.origin) return state;
 
 		url.preventDefault();
-		push = true;
 		url = link.href.replace(location.origin, '');
 	} else if (typeof url !== 'string') {
 		url = location.pathname + location.search;
+		push = undefined;
 	}
 
 	if (push === true) history.pushState(null, '', url);


### PR DESCRIPTION
At this moment routers' reducer dispatcher behaves as follows:

- User action (MouseEvent):
  window location is updated via `history.pushState`

- User navigation via back/ forward (PopStateEvent):
  window location is left intact, as it's change is handled by browser

- Manual route change via `useLocation().route(path)`
  window location is left intact

This PR
- Fixes last case so `history.pushState` is used to add new entry to browsers history and in effect location changes.
- Moves `push`  from dispatcher argument to function code block, As reducer dispatchers consume only two arguments. it gave false indication that the argument may be chosen somehow.
- Makes it clear that in reality there is no way to set `push` to false and in effect use `history.replaceState`