### PR TITLE
Treat ErrorBoundary as a Suspense root in `preact/debug`

### DIFF
--- a/.changeset/soft-fireants-call.md
+++ b/.changeset/soft-fireants-call.md
@@ -1,0 +1,5 @@
+---
+"preact-iso": patch
+---
+
+Treat ErrorBoundary as a Suspense root in `preact/debug`

--- a/packages/preact-iso/lazy.js
+++ b/packages/preact-iso/lazy.js
@@ -15,6 +15,7 @@ export default function lazy(load) {
 
 export function ErrorBoundary(props) {
 	this.componentDidCatch = absorb;
+	this._childDidSuspend = Object;
 	return props.children;
 }
 


### PR DESCRIPTION
Fixes #429.

Source reference: https://github.com/preactjs/preact/blob/cd8d65882d08af9f3b7d143d441d128ff068705c/debug/src/debug.js#L57