### PR TITLE
Use astronaut design for startup screen

### DIFF
--- a/.changeset/thin-coins-peel.md
+++ b/.changeset/thin-coins-peel.md
@@ -1,0 +1,5 @@
+---
+'wmr': patch
+---
+
+This PR adds a redesigned startup screen to make it easier to read addresses at a glance.

--- a/packages/wmr/src/lib/net-utils.js
+++ b/packages/wmr/src/lib/net-utils.js
@@ -39,10 +39,11 @@ export async function getFreePort(port) {
 /**
  * Display local and network origins for a server's address.
  * @param {net.AddressInfo|string} addr
+ * @returns {string[]}
  */
 export function getServerAddresses(addr, { https = false } = {}) {
 	if (typeof addr === 'string') {
-		return addr;
+		return [addr];
 	}
 
 	const protocol = https ? 'https:' : 'http:';
@@ -51,7 +52,7 @@ export function getServerAddresses(addr, { https = false } = {}) {
 
 	// Get network address
 	const ifaces = os.networkInterfaces();
-	const addresses = [];
+	const addresses = [`${protocol}//${host}:${port}`];
 	for (const name in ifaces) {
 		for (const iface of ifaces[name]) {
 			const { family, address, internal } = iface;
@@ -61,10 +62,5 @@ export function getServerAddresses(addr, { https = false } = {}) {
 		}
 	}
 
-	let out = `${protocol}//${host}:${port}`;
-	if (addresses.length) {
-		out += `\n  ⌙ ${addresses.join(', ')}`;
-	}
-
-	return out;
+	return addresses;
 }

--- a/packages/wmr/src/lib/output-utils.js
+++ b/packages/wmr/src/lib/output-utils.js
@@ -164,3 +164,31 @@ export function formatResolved(from, to) {
 	to = formatPath(to);
 	return `${kl.cyan(from)} -> ${kl.dim(to)}`;
 }
+
+/**
+ * @param {string} addr
+ */
+function formatAddr(addr) {
+	return kl.cyan(addr.replace(/:(\d+)$/, m => ':' + kl.bold(m.slice(1))));
+}
+
+/**
+ * @param {string} message
+ * @param {string[]} addresses
+ * @returns {string}
+ */
+export function formatBootMessage(message, addresses) {
+	const intro = `\n  👩‍🚀 WMR ${message}\n\n`;
+	const local = `  Local:   ${formatAddr(addresses[0])}\n`;
+
+	let network = '';
+	if (addresses.length > 1) {
+		network =
+			addresses
+				.slice(1)
+				.map(addr => `  Network: ${formatAddr(addr)}`)
+				.join('\n') + '\n';
+	}
+
+	return `${intro}${local}${network}\n`;
+}

--- a/packages/wmr/src/lib/output-utils.js
+++ b/packages/wmr/src/lib/output-utils.js
@@ -178,15 +178,15 @@ function formatAddr(addr) {
  * @returns {string}
  */
 export function formatBootMessage(message, addresses) {
-	const intro = `\n  👩‍🚀 WMR ${message}\n\n`;
-	const local = `  Local:   ${formatAddr(addresses[0])}\n`;
+	const intro = `\n👩‍🚀 ${kl.lightYellow('WMR')} ${message}\n`;
+	const local = `  ${kl.dim('Local:')}   ${formatAddr(addresses[0])}\n`;
 
 	let network = '';
 	if (addresses.length > 1) {
 		network =
 			addresses
 				.slice(1)
-				.map(addr => `  Network: ${formatAddr(addr)}`)
+				.map(addr => `  ${kl.dim('Network:')} ${formatAddr(addr)}`)
 				.join('\n') + '\n';
 	}
 

--- a/packages/wmr/src/serve.js
+++ b/packages/wmr/src/serve.js
@@ -6,6 +6,7 @@ import { createServer } from 'http';
 import { createHttp2Server } from './lib/http2.js';
 import compression from './lib/polkompress.js';
 import sirv from 'sirv';
+import { formatBootMessage } from './lib/output-utils.js';
 
 /**
  * @typedef CustomServer
@@ -101,6 +102,8 @@ export default async function serve(options = {}) {
 	const host = options.host || process.env.HOST;
 	app.listen(port, host, () => {
 		const addresses = getServerAddresses(app.server.address(), { https: app.http2 });
-		process.stdout.write(kl.cyan(`Listening on ${addresses}`) + '\n');
+
+		const message = `dev server running at:`;
+		process.stdout.write(formatBootMessage(message, addresses));
 	});
 }

--- a/packages/wmr/src/start.js
+++ b/packages/wmr/src/start.js
@@ -3,7 +3,7 @@ import wmrMiddleware from './wmr-middleware.js';
 import { getFreePort, getServerAddresses } from './lib/net-utils.js';
 import { normalizeOptions } from './lib/normalize-options.js';
 import { setCwd } from './plugins/npm-plugin/registry.js';
-import * as kl from 'kolorist';
+import { formatBootMessage } from './lib/output-utils.js';
 
 /**
  * @typedef OtherOptions
@@ -68,6 +68,7 @@ export default async function start(options = {}) {
 	const app = await server(options);
 	app.listen(options.port, options.host, () => {
 		const addresses = getServerAddresses(app.server.address(), { https: app.http2 });
-		process.stdout.write(kl.cyan(`Listening on ${addresses}`) + '\n');
+		const message = `server running at:`;
+		process.stdout.write(formatBootMessage(message, addresses));
 	});
 }

--- a/packages/wmr/test/boot.test.js
+++ b/packages/wmr/test/boot.test.js
@@ -22,14 +22,14 @@ describe('boot', () => {
 	it('should listen on port', async () => {
 		await loadFixture('simple', env);
 		instance = await runWmr(env.tmp.path);
-		await waitForMessage(instance.output, /(^Listening|^Error)/);
+		await waitForMessage(instance.output, /(server running at|^Error)/);
 
 		const output = instance.output.join('\n');
 
 		expect(output).not.toMatch(/^Error/m);
 
-		expect(output).toMatch(/Listening on http:\/\/localhost:\d+/);
-		expect(output).toMatch(/⌙ http:\/\/\d+.\d+.\d+.\d+:\d+/);
+		expect(output).toMatch(/server running at/);
+		expect(output).toMatch(/Network:\s+http:\/\/\d+.\d+.\d+.\d+:\d+/);
 	});
 
 	it('should build simple HTML pages', async () => {

--- a/packages/wmr/test/test-helpers.js
+++ b/packages/wmr/test/test-helpers.js
@@ -88,7 +88,7 @@ export async function runWmr(cwd, ...args) {
 		if (/\b([A-Z][a-z]+)?Error\b/m.test(raw) && !/^404 /.test(raw)) {
 			console.error(`Error running "wmr ${args.join(' ')}":\n${raw}`);
 		}
-		if (/^Listening/m.test(raw)) {
+		if (/server running at/m.test(raw)) {
 			let m = raw.match(/https?:\/\/localhost:\d+/g);
 			if (m) setAddress(m[0]);
 		}
@@ -114,7 +114,7 @@ const addrs = new WeakMap();
 export async function getOutput(env, instance) {
 	let address = addrs.get(instance);
 	if (!address) {
-		await waitForMessage(instance.output, /^Listening/);
+		await waitForMessage(instance.output, /server running at/);
 		address = instance.output.join('\n').match(/https?:\/\/localhost:\d+/g)[0];
 		addrs.set(instance, address);
 	}


### PR DESCRIPTION
This PR adds a redesigned startup screen. It tries to fit with the logo we'll share soon.

Before:

<img width="521" alt="Screenshot 2021-03-19 at 01 55 33" src="https://user-images.githubusercontent.com/1062408/111716388-37d1e680-8856-11eb-98a3-516ed24fedab.png">

After:

<img width="381" alt="Screenshot 2021-03-19 at 02 00 28" src="https://user-images.githubusercontent.com/1062408/111716711-e37b3680-8856-11eb-88ee-e0c2dc90fb16.png">
