### PR TITLE
Align astronaut emoji with addresses in cli

### DIFF
--- a/.changeset/silver-steaks-sniff.md
+++ b/.changeset/silver-steaks-sniff.md
@@ -1,0 +1,5 @@
+---
+'wmr': patch
+---
+
+Align astronaut emoji with addresses in startup message

--- a/packages/wmr/src/lib/output-utils.js
+++ b/packages/wmr/src/lib/output-utils.js
@@ -178,7 +178,7 @@ function formatAddr(addr) {
  * @returns {string}
  */
 export function formatBootMessage(message, addresses) {
-	const intro = `\n👩‍🚀 ${kl.lightYellow('WMR')} ${message}\n`;
+	const intro = `\n  👩‍🚀 ${kl.lightYellow('WMR')} ${message}\n\n`;
 	const local = `  ${kl.dim('Local:')}   ${formatAddr(addresses[0])}\n`;
 
 	let network = '';


### PR DESCRIPTION
I messed up the last commit in #450 when applying the review comments.

Before:
<img width="351" alt="Screenshot 2021-03-20 at 17 58 31" src="https://user-images.githubusercontent.com/1062408/111877951-0c5e1180-89a6-11eb-9a6f-2d086d530421.png">

After:
<img width="365" alt="Screenshot 2021-03-20 at 17 58 45" src="https://user-images.githubusercontent.com/1062408/111877952-0cf6a800-89a6-11eb-992a-03dc70a8e02e.png">
