### PR TITLE
fix: Ensures WMR types are available to user

### DIFF
--- a/.changeset/spicy-hornets-provide.md
+++ b/.changeset/spicy-hornets-provide.md
@@ -1,0 +1,5 @@
+---
+'create-wmr': patch
+---
+
+Ensures WMR's types are available to users

--- a/packages/create-wmr/tpl/tsconfig.json
+++ b/packages/create-wmr/tpl/tsconfig.json
@@ -15,7 +15,7 @@
 		"allowSyntheticDefaultImports": true,
 		"downlevelIteration": true
 	},
-	"files": ["./node_modules/wmr/index.d.ts"],
+	"include": ["node_modules/wmr/index.d.ts"],
 	"typeAcquisition": {
 		"enable": true
 	}

--- a/packages/create-wmr/tpl/tsconfig.json
+++ b/packages/create-wmr/tpl/tsconfig.json
@@ -15,6 +15,7 @@
 		"allowSyntheticDefaultImports": true,
 		"downlevelIteration": true
 	},
+	"files": ["./node_modules/wmr/index.d.ts"],
 	"typeAcquisition": {
 		"enable": true
 	}


### PR DESCRIPTION
Fixes https://github.com/preactjs/wmr/issues/259#issuecomment-805316476

JetBrains tools won't automatically load WMR's types, while I think VSCode and some others do. This should ensure better tooling parity.

Solution proposed by @danielweck https://github.com/preactjs/wmr/issues/259#issuecomment-805371513