### PR TITLE
Throw if the user requests a port and it's already taken

### DIFF
--- a/.changeset/warm-jars-fetch.md
+++ b/.changeset/warm-jars-fetch.md
@@ -1,0 +1,5 @@
+---
+'wmr': patch
+---
+
+Always throw if the user requested a specific port and it's not available


### PR DESCRIPTION
Before this PR we'd silently choose a different port, even if the user explicitely requested one via `--port` or `process.env.PORT`