### PR TITLE
Always print stack traces on exceptions

### DIFF
--- a/.changeset/clean-ads-obey.md
+++ b/.changeset/clean-ads-obey.md
@@ -1,0 +1,5 @@
+---
+'wmr': patch
+---
+
+Always print stack traces on exceptions

--- a/packages/wmr/package.json
+++ b/packages/wmr/package.json
@@ -111,6 +111,7 @@
 		"cross-env": "^7.0.2",
 		"cssnano": "^4.1.10",
 		"devcert": "^1.1.2",
+		"errorstacks": "^2.3.0",
 		"es-module-lexer": "^0.4.1",
 		"eslint": "^7.4.0",
 		"eslint-config-developit": "^1.2.0",

--- a/packages/wmr/src/cli.js
+++ b/packages/wmr/src/cli.js
@@ -4,6 +4,7 @@ import sade from 'sade';
 import build from './build.js';
 import start from './start.js';
 import serve from './serve.js';
+import * as errorstacks from 'errorstacks';
 import * as kl from 'kolorist';
 
 const prog = sade('wmr');
@@ -51,8 +52,13 @@ prog.parse(process.argv);
 
 function run(p) {
 	p.catch(err => {
-		const text = (process.env.DEBUG ? err.stack : err.message) || err + '';
-		process.stderr.write(`${kl.red(text)}\n`);
+		const text = err.message || err + '';
+		const stack =
+			errorstacks
+				.parseStackTrace(err.stack)
+				.map(frame => frame.raw)
+				.join('\n') + '\n';
+		process.stderr.write(`\n${kl.red(text)}\n${kl.dim(stack)}\n`);
 		process.exit(p.code || 1);
 	});
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2828,6 +2828,11 @@ error-ex@^1.2.0, error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
+errorstacks@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/errorstacks/-/errorstacks-2.3.0.tgz#3073cab243ad3af0c4797ec329f3aa599f0a34df"
+  integrity sha512-VjCIUbEyLymy2N1M/uTniewz+j69YC2R7Sp1UiJn04RHwyIniBib6hUZwgmphAAZTOk7LRg/wryGFEJhblEd7Q==
+
 es-abstract@^1.17.2:
   version "1.17.7"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.17.7.tgz#a4de61b2f66989fc7421676c1cb9787573ace54c"


### PR DESCRIPTION
Before:

<img width="788" alt="Screenshot 2021-03-27 at 10 49 56" src="https://user-images.githubusercontent.com/1062408/112717028-38b7e780-8eea-11eb-804f-c2ef029bc0e5.png">

After:

<img width="863" alt="Screenshot 2021-03-27 at 10 47 48" src="https://user-images.githubusercontent.com/1062408/112717033-3ce40500-8eea-11eb-8eee-8c036f95f48d.png">
