### PR TITLE
Fix wrong plugin ordering

### DIFF
--- a/.changeset/violet-grapes-sparkle.md
+++ b/.changeset/violet-grapes-sparkle.md
@@ -1,0 +1,5 @@
+---
+'wmr': patch
+---
+
+Fix incorrect plugin ordering introduced in #465 (unreleased)

--- a/packages/wmr/src/bundler.js
+++ b/packages/wmr/src/bundler.js
@@ -88,7 +88,7 @@ export async function bundleProd({
 	});
 
 	// Plugins are pre-sorted
-	const split = plugins.findIndex(p => p.enforce !== 'post');
+	const split = plugins.findIndex(p => p.enforce === 'post');
 
 	const bundle = await rollup.rollup({
 		input,

--- a/packages/wmr/src/wmr-middleware.js
+++ b/packages/wmr/src/wmr-middleware.js
@@ -66,7 +66,7 @@ export default function wmrMiddleware({
 	root = root || cwd;
 
 	// Plugins are pre-sorted
-	const split = plugins.findIndex(p => p.enforce !== 'post');
+	const split = plugins.findIndex(p => p.enforce === 'post');
 	const NonRollup = createPluginContainer(
 		[
 			...plugins.slice(0, split),


### PR DESCRIPTION
Regression was introduced with #465 (unreleased)