### PR TITLE
Use jest matchers to better inspect mismatches

### DIFF
--- a/packages/wmr/test/production.test.js
+++ b/packages/wmr/test/production.test.js
@@ -241,17 +241,17 @@ describe('production', () => {
 			const main = await fs.readFile(path.join(env.tmp.path, 'dist', roots[2]), 'utf8');
 
 			// https://cdn.example.com/assets/math.d41e7373.css
-			expect(math.includes(`("https://cdn.example.com/assets/${assets[1]}")`)).toBe(true);
-			expect(math.includes(`import("./${chunks[0]}")`)).toBe(true);
+			expect(math).toMatch(`("https://cdn.example.com/assets/${assets[1]}")`);
+			expect(math).toMatch(`import("./${chunks[0]}")`);
 
 			// (preload) https://cdn.example.com/assets/math.d41e7373.css
-			expect(main.includes(`$w_s$("https://cdn.example.com/assets/${assets[1]}")`)).toBe(true);
+			expect(main).toMatch(`$w_s$("https://cdn.example.com/assets/${assets[1]}")`);
 
 			// HTML stylesheet: https://cdn.example.com/assets/index.0544f0a6.css
-			expect(html.includes(`href="https://cdn.example.com/assets/${assets[0]}"`)).toBe(true);
+			expect(html).toMatch(`href="https://cdn.example.com/assets/${assets[0]}"`);
 
 			// HTML script: https://cdn.example.com/assets/index.0544f0a6.css
-			expect(html.includes(`src="https://cdn.example.com/${roots[2]}"`)).toBe(true);
+			expect(html).toMatch(`src="https://cdn.example.com/${roots[2]}"`);
 		});
 
 		it('should respect `config.publicPath` value (ts)', async () => {
@@ -278,17 +278,17 @@ describe('production', () => {
 			const main = await fs.readFile(path.join(env.tmp.path, 'dist', roots[2]), 'utf8');
 
 			// https://cdn.example.com/assets/math.d41e7373.css
-			expect(math.includes(`("https://cdn.example.com/assets/${assets[1]}")`)).toBe(true);
-			expect(math.includes(`import("./${chunks[0]}")`)).toBe(true);
+			expect(math).toMatch(`("https://cdn.example.com/assets/${assets[1]}")`);
+			expect(math).toMatch(`import("./${chunks[0]}")`);
 
 			// (preload) https://cdn.example.com/assets/math.d41e7373.css
-			expect(main.includes(`$w_s$("https://cdn.example.com/assets/${assets[1]}")`)).toBe(true);
+			expect(main).toMatch(`$w_s$("https://cdn.example.com/assets/${assets[1]}")`);
 
 			// HTML stylesheet: https://cdn.example.com/assets/index.0544f0a6.css
-			expect(html.includes(`href="https://cdn.example.com/assets/${assets[0]}"`)).toBe(true);
+			expect(html).toMatch(`href="https://cdn.example.com/assets/${assets[0]}"`);
 
 			// HTML script: https://cdn.example.com/assets/index.0544f0a6.css
-			expect(html.includes(`src="https://cdn.example.com/${roots[2]}"`)).toBe(true);
+			expect(html).toMatch(`src="https://cdn.example.com/${roots[2]}"`);
 		});
 	});
 


### PR DESCRIPTION
With `toBe()` we see nothing:

<img width="554" alt="Screenshot 2021-03-28 at 08 47 55" src="https://user-images.githubusercontent.com/1062408/112744857-e89d5b80-8fa3-11eb-9123-b28e074e298d.png">

With `toMatch()` it prints both strings:

<img width="452" alt="Screenshot 2021-03-28 at 08 47 59" src="https://user-images.githubusercontent.com/1062408/112744861-f18e2d00-8fa3-11eb-8992-046261bd14dc.png">

