### PR TITLE
Bugfix: correctly invoke plugins when there are no enforce:post plugins

### DIFF
--- a/.changeset/curvy-adults-reflect.md
+++ b/.changeset/curvy-adults-reflect.md
@@ -1,0 +1,5 @@
+---
+"wmr": patch
+---
+
+Bugfix: correctly invoke registered plugins when there are no plugins with `{enforce:"post"}` present.

--- a/packages/wmr/src/lib/plugins.js
+++ b/packages/wmr/src/lib/plugins.js
@@ -28,7 +28,8 @@ export function getPlugins(options) {
 	const { plugins, cwd, publicPath, aliases, root, env, minify, mode, sourcemap, features } = options;
 
 	// Plugins are pre-sorted
-	const split = plugins.findIndex(p => p.enforce === 'post');
+	let split = plugins.findIndex(p => p.enforce === 'post');
+	if (split === -1) split = plugins.length;
 
 	const production = mode === 'build';
 


### PR DESCRIPTION
Fixes #490.