### PR TITLE
[preact-iso] Router should ignore links with target=".."

### DIFF
--- a/.changeset/yellow-peas-decide.md
+++ b/.changeset/yellow-peas-decide.md
@@ -1,0 +1,5 @@
+---
+"preact-iso": patch
+---
+
+[preact-iso] Prevent the Router from intercepting clicks on links with an "external" target (`target="anything"`).

--- a/packages/preact-iso/router.js
+++ b/packages/preact-iso/router.js
@@ -5,7 +5,7 @@ const UPDATE = (state, url) => {
 	let push = true;
 	if (url && url.type === 'click') {
 		const link = url.target.closest('a[href]');
-		if (!link || link.origin != location.origin) return state;
+		if (!link || link.origin != location.origin || !/^(_?self)?$/i.test(link.target)) return state;
 
 		url.preventDefault();
 		url = link.href.replace(location.origin, '');

--- a/packages/preact-iso/test/router.test.js
+++ b/packages/preact-iso/test/router.test.js
@@ -1,5 +1,6 @@
 import { jest, describe, it, beforeEach, expect } from '@jest/globals';
-import { h, html, render } from 'htm/preact';
+import { h, render } from 'preact';
+import { html } from 'htm/preact';
 import { LocationProvider, Router, useLocation } from '../router.js';
 import lazy, { ErrorBoundary } from '../lazy.js';
 


### PR DESCRIPTION
This prevents the Router's link handling from intercepting clicks on links with `<a target="anything">`. Only these cases will be intercepted:

```
<a />
<a target="self" />
<a target="_self" />
<a target="_SELF" />
```

Fixes #488.