### PR TITLE
Bugfix: show stack trace for prerendering errors instead of crashing

### DIFF
--- a/.changeset/dull-bags-attack.md
+++ b/.changeset/dull-bags-attack.md
@@ -1,0 +1,5 @@
+---
+"wmr": patch
+---
+
+Bugfix: Fix a crash when prerendering encounters an error, and show pretty-printed stack traces instead.

--- a/packages/wmr/package.json
+++ b/packages/wmr/package.json
@@ -111,7 +111,7 @@
 		"cross-env": "^7.0.2",
 		"cssnano": "^4.1.10",
 		"devcert": "^1.1.2",
-		"errorstacks": "^2.3.0",
+		"errorstacks": "^2.3.2",
 		"es-module-lexer": "^0.4.1",
 		"eslint": "^7.4.0",
 		"eslint-config-developit": "^1.2.0",

--- a/packages/wmr/src/cli.js
+++ b/packages/wmr/src/cli.js
@@ -53,12 +53,15 @@ prog.parse(process.argv);
 function run(p) {
 	p.catch(err => {
 		const text = err.message || err + '';
-		const stack =
-			errorstacks
-				.parseStackTrace(err.stack)
-				.map(frame => frame.raw)
-				.join('\n') + '\n';
-		process.stderr.write(`\n${kl.red(text)}\n${kl.dim(stack)}\n`);
+		let stack = err.stack;
+		if (stack) {
+			stack =
+				errorstacks
+					.parseStackTrace(stack)
+					.map(frame => frame.raw)
+					.join('\n') + '\n\n';
+		}
+		process.stderr.write(`\n${kl.red(text)}\n${stack ? kl.dim(stack) : ''}`);
 		process.exit(p.code || 1);
 	});
 }

--- a/packages/wmr/src/cli.js
+++ b/packages/wmr/src/cli.js
@@ -53,15 +53,12 @@ prog.parse(process.argv);
 function run(p) {
 	p.catch(err => {
 		const text = err.message || err + '';
-		let stack = err.stack;
-		if (stack) {
-			stack =
-				errorstacks
-					.parseStackTrace(stack)
-					.map(frame => frame.raw)
-					.join('\n') + '\n\n';
-		}
-		process.stderr.write(`\n${kl.red(text)}\n${stack ? kl.dim(stack) : ''}`);
+		const stack = errorstacks
+			.parseStackTrace(err.stack)
+			.map(frame => frame.raw)
+			.join('\n');
+
+		process.stderr.write(`\n${kl.red(text)}\n${stack ? kl.dim(stack + '\n\n') : ''}`);
 		process.exit(p.code || 1);
 	});
 }

--- a/packages/wmr/test/fixtures/prerender-crash/index.html
+++ b/packages/wmr/test/fixtures/prerender-crash/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf8" />
+		<title>default title</title>
+	</head>
+	<body>
+		<script src="./index.js" type="module"></script>
+	</body>
+</html>

--- a/packages/wmr/test/fixtures/prerender-crash/index.js
+++ b/packages/wmr/test/fixtures/prerender-crash/index.js
@@ -1,0 +1,3 @@
+export function prerender() {
+	throw new Error('fail');
+}

--- a/packages/wmr/test/production.test.js
+++ b/packages/wmr/test/production.test.js
@@ -338,6 +338,17 @@ describe('production', () => {
 			const index = await fs.readFile(indexHtml, 'utf8');
 			expect(index).toMatch(/{"foo":42,"bar":"bar"}/);
 		});
+
+		it('should not crash during prerendering', async () => {
+			await loadFixture('prerender-crash', env);
+			instance = await runWmr(env.tmp.path, 'build', '--prerender');
+			const code = await instance.done;
+			console.info(instance.output.join('\n'));
+			expect(instance.output.join('\n')).toMatch(/Error: fail/);
+			// Check if stack trace is present
+			expect(instance.output.join('\n')).toMatch(/^\s+at\s\w+/gm);
+			expect(code).toBe(1);
+		});
 	});
 
 	describe('Code Splitting', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3084,10 +3084,10 @@ error-ex@^1.2.0, error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
-errorstacks@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/errorstacks/-/errorstacks-2.3.0.tgz#3073cab243ad3af0c4797ec329f3aa599f0a34df"
-  integrity sha512-VjCIUbEyLymy2N1M/uTniewz+j69YC2R7Sp1UiJn04RHwyIniBib6hUZwgmphAAZTOk7LRg/wryGFEJhblEd7Q==
+errorstacks@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/errorstacks/-/errorstacks-2.3.2.tgz#cab2c7c83e199a2b2862de3fea46f68372094166"
+  integrity sha512-cJp8qf5t2cXmVZJjZVrcU4ODFJeQOcUyjJEtPFtWO+3N6JPM6vCe4Sfv3cwIs/qS7gnUo/fvKX/mDCVQZq+P7A==
 
 es-abstract@^1.17.2:
   version "1.17.7"


### PR DESCRIPTION
Prerendering errors are Strings because they're sent from a Worker. This parses them back into Error objects and falsifies the `.stack` property so it gets pretty printed. It also adds a guard around the stack trace parsing, which was throwing an exception when we tried to give it an undefined `error.stack` (it expects a String).