### PR TITLE
Update docs command

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 	"scripts": {
 		"wmr": "yarn workspace wmr run",
 		"demo": "yarn workspace @examples/demo run",
-		"docs": "yarn workspace docs build",
+		"docs": "yarn workspace docs",
 		"ci": "yarn wmr build && yarn --check-files && yarn demo build:prod"
 	},
 	"eslintConfig": {


### PR DESCRIPTION
This makes it possible to work on docs by calling `yarn docs start`. The netlify script is already updated to use `yarn docs build`