### PR TITLE
Fix bad publish of 1.5.0

### DIFF
--- a/.changeset/curvy-brooms-begin.md
+++ b/.changeset/curvy-brooms-begin.md
@@ -1,0 +1,5 @@
+---
+'wmr': patch
+---
+
+Fix missing dependency `rollup-plugin-visualize` (bad publish of 1.5.0)


### PR DESCRIPTION
Looks like I did the publish with an old `node_modules` folder. We should really switch to changesets publish action!