### PR TITLE
create-wmr template: Fix file path in tsconfig

### DIFF
--- a/.changeset/friendly-brooms-shout.md
+++ b/.changeset/friendly-brooms-shout.md
@@ -1,0 +1,5 @@
+---
+'create-wmr': patch
+---
+
+Correcting file path in template's tsconfig "include"

--- a/packages/create-wmr/tpl/tsconfig.json
+++ b/packages/create-wmr/tpl/tsconfig.json
@@ -15,7 +15,7 @@
 		"allowSyntheticDefaultImports": true,
 		"downlevelIteration": true
 	},
-	"include": ["node_modules/wmr/index.d.ts"],
+	"include": ["node_modules/wmr/types.d.ts"],
 	"typeAcquisition": {
 		"enable": true
 	}


### PR DESCRIPTION
My fault, I copy/pasted that from some comment without manually checking. It'll "silence errors" only because `public` is then not included. If the users add this, the previous "fix" breaks.