### PR TITLE
revert: Restoring default tsconfig include behavior

### DIFF
--- a/packages/create-wmr/tpl/tsconfig.json
+++ b/packages/create-wmr/tpl/tsconfig.json
@@ -15,7 +15,7 @@
 		"allowSyntheticDefaultImports": true,
 		"downlevelIteration": true
 	},
-	"include": ["node_modules/wmr/types.d.ts"],
+	"include": ["node_modules/wmr/types.d.ts", "**/*"],
 	"typeAcquisition": {
 		"enable": true
 	}


### PR DESCRIPTION
Default behavior for `"include"` is `["**/*"]` ->  https://www.typescriptlang.org/tsconfig#include

Adding this will get that default back, while ensuring JetBrains IDEs include that ambient type declaration file. Else users will need to make sure to add `public` or other paths to their tsconfig