### PR TITLE
(preact-iso) - handle cancelled renders

### DIFF
--- a/examples/demo/public/lib/lazy.js
+++ b/examples/demo/public/lib/lazy.js
@@ -3,23 +3,23 @@ import { useState, useRef } from 'preact/hooks';
 
 export default function lazy(load) {
 	let p, c;
-	function inner(props) {
-		if (!p) p = load().then(m => ((c = (m && m.default) || m), 1));
+	return props => {
 		const [, update] = useState(0);
 		const r = useRef(c);
-		if (!r.current) r.current = p.then(update);
-		if (c === undefined) throw p;
-		return h(c, props);
-	}
-
-	return inner;
+		if (!p) p = load().then(m => (c = (m && m.default) || m));
+		if (c !== undefined) return h(c, props);
+		if (!r.current) r.current = p.then(() => update(1));
+		throw p;
+	};
 }
 
 export function ErrorBoundary(props) {
 	this.componentDidCatch = absorb;
 	return props.children;
 }
+
 function absorb(err) {
 	if (err && err.then) this.__d = true;
+	// @ts-ignore
 	else if (this.props.onError) this.props.onError(err);
 }

--- a/examples/demo/public/lib/loc.js
+++ b/examples/demo/public/lib/loc.js
@@ -122,6 +122,7 @@ export function Router(props) {
 				cur.current.url = url;
 				prevChildren.current = null;
 				curChildren.current = h(Committer, {}, h(RouteContext.Provider, { value: m }, p || d));
+				if (wasPush) scrollTo(0, 0);
 				update(0);
 				return;
 			} else {

--- a/examples/demo/public/lib/loc.js
+++ b/examples/demo/public/lib/loc.js
@@ -104,7 +104,7 @@ export function Router(props) {
 		});
 
 		return h(Committer, {}, h(RouteContext.Provider, { value: m }, p || d));
-	}, [url, path, query]);
+	}, [url]);
 
 	useLayoutEffect(() => {
 		let p = pending.current;

--- a/packages/preact-iso/router.js
+++ b/packages/preact-iso/router.js
@@ -122,6 +122,7 @@ export function Router(props) {
 				cur.current.url = url;
 				prevChildren.current = null;
 				curChildren.current = h(Committer, {}, h(RouteContext.Provider, { value: m }, p || d));
+				if (wasPush) scrollTo(0, 0);
 				update(0);
 				return;
 			} else {

--- a/packages/preact-iso/router.js
+++ b/packages/preact-iso/router.js
@@ -123,13 +123,11 @@ export function Router(props) {
 				prevChildren.current = null;
 				curChildren.current = h(Committer, {}, h(RouteContext.Provider, { value: m }, p || d));
 				if (wasPush) scrollTo(0, 0);
-				if (this.__v && this.__v.__k) this.__v.__k.reverse();
 				update(0);
 				return;
 			} else {
 				prev.current = prevChildren.current = pending.current = null;
 				if (props.onLoadEnd) props.onLoadEnd(url);
-				if (this.__v && this.__v.__k) this.__v.__k.reverse();
 				update(0);
 				if (wasPush) scrollTo(0, 0);
 			}

--- a/packages/preact-iso/router.js
+++ b/packages/preact-iso/router.js
@@ -104,7 +104,7 @@ export function Router(props) {
 		});
 
 		return h(Committer, {}, h(RouteContext.Provider, { value: m }, p || d));
-	}, [url, path, query]);
+	}, [url]);
 
 	useLayoutEffect(() => {
 		let p = pending.current;

--- a/packages/preact-iso/router.js
+++ b/packages/preact-iso/router.js
@@ -123,11 +123,13 @@ export function Router(props) {
 				prevChildren.current = null;
 				curChildren.current = h(Committer, {}, h(RouteContext.Provider, { value: m }, p || d));
 				if (wasPush) scrollTo(0, 0);
+				if (this.__v && this.__v.__k) this.__v.__k.reverse();
 				update(0);
 				return;
 			} else {
 				prev.current = prevChildren.current = pending.current = null;
 				if (props.onLoadEnd) props.onLoadEnd(url);
+				if (this.__v && this.__v.__k) this.__v.__k.reverse();
 				update(0);
 				if (wasPush) scrollTo(0, 0);
 			}

--- a/packages/preact-iso/test/router.test.js
+++ b/packages/preact-iso/test/router.test.js
@@ -154,7 +154,8 @@ describe('Router', () => {
 
 		await sleep(1);
 
-		expect(scratch).toHaveProperty('innerHTML', '<h1>A</h1><p>hello</p>');
+		// DOM-transition
+		expect(scratch).toHaveProperty('innerHTML', '');
 		// We should never re-invoke <A /> while loading <B /> (that would be a remount of the old route):
 		expect(A).not.toHaveBeenCalled();
 		expect(B).toHaveBeenCalledWith({ path: '/b', query: {} }, expect.anything());
@@ -180,7 +181,8 @@ describe('Router', () => {
 		loc.route('/c?2');
 		loc.route('/c');
 
-		expect(scratch).toHaveProperty('innerHTML', '<h1>B</h1><p>hello</p>');
+		// DOM-transition
+		expect(scratch).toHaveProperty('innerHTML', '');
 		// We should never re-invoke <A /> while loading <B /> (that would be a remount of the old route):
 		expect(B).not.toHaveBeenCalled();
 		expect(C).toHaveBeenCalledWith({ path: '/c', query: {} }, expect.anything());


### PR DESCRIPTION
By removing the synchronous render work we remove a few race conditions that were assumed to never occur, in this case when a pre-rendered route was used and we navigated away from it, the pre-rendered route would come back later and re-insert itself as the first child.

Fixes #425

CC @danielweck in case you have a mo, could you test this 😅 been doing a lot of testing but our tests don't seem to agree with me, mainly wondering if I'm missing something important