### PR TITLE
Include .wasm files in streamed packages

### DIFF
--- a/.changeset/hot-rabbits-travel.md
+++ b/.changeset/hot-rabbits-travel.md
@@ -1,0 +1,5 @@
+---
+"wmr": patch
+---
+
+Include `.wasm` files in streamed npm packages

--- a/packages/wmr/src/plugins/npm-plugin/registry.js
+++ b/packages/wmr/src/plugins/npm-plugin/registry.js
@@ -30,7 +30,7 @@ import sizeWarningPlugin from './size-warning-plugin.js';
  */
 
 /** Files that should be included when storing packages */
-const FILES_INCLUDE = /\.(js|mjs|cjs|json|tsx?|css)$/i;
+const FILES_INCLUDE = /\.(js|mjs|cjs|json|tsx?|css|wasm)$/i;
 
 /** Files that should always be ignored when storing packages */
 const FILES_EXCLUDE = /([._-]test\.|__tests?|\/tests?\/|\/node_modules\/)/i;


### PR DESCRIPTION
We only include files with extensions WMR can deal with, but we support WASM so it should be included.