### PR TITLE
Always run CSS through stylis to support nesting/etc

### DIFF
--- a/.changeset/shaggy-laws-cry.md
+++ b/.changeset/shaggy-laws-cry.md
@@ -1,0 +1,5 @@
+---
+"wmr": patch
+---
+
+Process all CSS to compile nested selectors, instead of only CSS Modules.

--- a/packages/wmr/src/plugins/wmr/styles-plugin.js
+++ b/packages/wmr/src/plugins/wmr/styles-plugin.js
@@ -124,7 +124,6 @@ export default function wmrStylesPlugin({ cwd, hot, fullPath } = {}) {
 			if (isModular) {
 				source = await modularizeCss(source, idRelative, mappings, id);
 			} else {
-				// } else if (isSass || isIcss) {
 				if (isIcss) {
 					console.warn(`Warning: ICSS ("composes:") is only supported in CSS Modules.`);
 				}

--- a/packages/wmr/src/plugins/wmr/styles-plugin.js
+++ b/packages/wmr/src/plugins/wmr/styles-plugin.js
@@ -114,7 +114,6 @@ export default function wmrStylesPlugin({ cwd, hot, fullPath } = {}) {
 			if (!id.match(/\.(css|s[ac]ss)$/)) return;
 			if (id[0] === '\b' || id[0] === '\0') return;
 
-			const isSass = /\.s[ac]ss$/.test(id);
 			const isIcss = /(composes:|:global|:local)/.test(source);
 			const isModular = /\.module\.(css|s[ac]ss)$/.test(id);
 
@@ -124,7 +123,8 @@ export default function wmrStylesPlugin({ cwd, hot, fullPath } = {}) {
 			const mappings = [];
 			if (isModular) {
 				source = await modularizeCss(source, idRelative, mappings, id);
-			} else if (isSass || isIcss) {
+			} else {
+				// } else if (isSass || isIcss) {
 				if (isIcss) {
 					console.warn(`Warning: ICSS ("composes:") is only supported in CSS Modules.`);
 				}


### PR DESCRIPTION
I've been using CSS Modules, which was effectively enabling this for me. I don't think we have any reason not to pass stuff through Stylis - it adds nesting support and whatnot.