### PR TITLE
[docs] Fix ThemeSwitcher hydration mismatch

### DIFF
--- a/docs/public/components/theme-switcher.js
+++ b/docs/public/components/theme-switcher.js
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from 'preact/hooks';
+import { useCallback, useEffect, useRef } from 'preact/hooks';
 import { useLocalStorage } from '../lib/use-localstorage.js';
 
 /**
@@ -7,9 +7,9 @@ import { useLocalStorage } from '../lib/use-localstorage.js';
 function ThemeItem(props) {
 	const { next, active, value, onChange } = props;
 	return (
-		<>
+		<label class="theme-btn" data-active={active === value} data-next={next === value}>
+			<img src={`/assets/${value}.svg`} class="icon" alt={`${value} theme`} width="20" height="20" />
 			<input
-				id={`theme-${value}`}
 				name="theme"
 				type="radio"
 				value={value}
@@ -17,17 +17,14 @@ function ThemeItem(props) {
 				onClick={onChange}
 				checked={active === value}
 			/>
-			<label for={`theme-${value}`} class="theme-btn" data-active={active === value} data-next={next === value}>
-				<img src={`/assets/${value}.svg`} class="icon" alt={`${value} theme`} width="20" height="20" />
-			</label>
-		</>
+		</label>
 	);
 }
 
 const THEMES = ['auto', 'dark', 'light', 'teatime'];
 
 export function ThemeSwitcher(props) {
-	const [theme, setTheme] = useLocalStorage('theme', THEMES[0]);
+	const [theme, setTheme] = useLocalStorage('theme', THEMES[0], true);
 	const idx = THEMES.indexOf(theme);
 	const next = THEMES[idx + 1] || THEMES[0];
 
@@ -35,8 +32,13 @@ export function ThemeSwitcher(props) {
 		setTheme(e.target.value);
 	}, []);
 
+	const first = useRef(true);
+
 	useEffect(() => {
-		if (theme === 'auto') {
+		if (first.current) {
+			// ignore the first render, which is just "auto" for hydration
+			first.current = false;
+		} else if (theme === 'auto') {
 			document.documentElement.removeAttribute('theme');
 		} else {
 			document.documentElement.setAttribute('theme', theme);

--- a/docs/public/index.html
+++ b/docs/public/index.html
@@ -4,6 +4,7 @@
 		<meta charset="utf-8" />
 		<title>WMR</title>
 		<meta name="viewport" content="width=device-width,initial-scale=1" />
+		<script>try{document.documentElement.setAttribute('theme',localStorage.theme.toString()))}catch(e){}</script>
 		<link rel="stylesheet" href="/styles/index.css" />
 		<link rel="icon" href="/assets/wmr.svg" />
 	</head>

--- a/docs/public/index.html
+++ b/docs/public/index.html
@@ -4,7 +4,7 @@
 		<meta charset="utf-8" />
 		<title>WMR</title>
 		<meta name="viewport" content="width=device-width,initial-scale=1" />
-		<script>try{let t=localStorage.theme;t&&t!='auto'&&document.documentElement.setAttribute('theme',t))}catch(e){}</script>
+		<script>try{let t=localStorage.theme;t&&t!='auto'&&document.documentElement.setAttribute('theme',t)}catch(e){}</script>
 		<link rel="stylesheet" href="/styles/index.css" />
 		<link rel="icon" href="/assets/wmr.svg" />
 	</head>

--- a/docs/public/index.html
+++ b/docs/public/index.html
@@ -4,7 +4,7 @@
 		<meta charset="utf-8" />
 		<title>WMR</title>
 		<meta name="viewport" content="width=device-width,initial-scale=1" />
-		<script>try{document.documentElement.setAttribute('theme',localStorage.theme.toString()))}catch(e){}</script>
+		<script>try{let t=localStorage.theme;t&&t!='auto'&&document.documentElement.setAttribute('theme',t))}catch(e){}</script>
 		<link rel="stylesheet" href="/styles/index.css" />
 		<link rel="icon" href="/assets/wmr.svg" />
 	</head>

--- a/docs/public/lib/use-localstorage.js
+++ b/docs/public/lib/use-localstorage.js
@@ -1,4 +1,4 @@
-import { useState } from 'preact/hooks';
+import { useState, useLayoutEffect } from 'preact/hooks';
 
 const SUPPORTS_LOCAL_STORAGE = typeof localStorage !== 'undefined';
 
@@ -19,7 +19,7 @@ export function useLocalStorage(key, initial, hydrateWithInitial) {
 		return stored == null ? initial : stored;
 	});
 	
-	useEffect(() => {
+	useLayoutEffect(() => {
 		if (hydrateWithInitial) {
 			const stored = getItem(key);
 			if (stored != null) setValue(stored);

--- a/docs/public/lib/use-localstorage.js
+++ b/docs/public/lib/use-localstorage.js
@@ -2,14 +2,29 @@ import { useState } from 'preact/hooks';
 
 const SUPPORTS_LOCAL_STORAGE = typeof localStorage !== 'undefined';
 
+function getItem(key) {
+	if (SUPPORTS_LOCAL_STORAGE) {
+		try {
+			return localStorage.getItem(key);
+		} catch (e) {}
+	}
+}
+
 /**
- * @type {<T>(name: string, value: T) => [T, (v: T) => void]}
+ * @type {<T>(name: string, value: T, hydrateWithInitial: boolean) => [T, (v: T) => void]}
  */
-export function useLocalStorage(key, initial) {
+export function useLocalStorage(key, initial, hydrateWithInitial) {
 	const [v, setValue] = useState(() => {
-		const stored = SUPPORTS_LOCAL_STORAGE ? localStorage.getItem(key) : null;
-		return stored === null ? initial : stored;
+		const stored = hydrateWithInitial ? null : getItem(key);
+		return stored == null ? initial : stored;
 	});
+	
+	useEffect(() => {
+		if (hydrateWithInitial) {
+			const stored = getItem(key);
+			if (stored != null) setValue(stored);
+		}
+	}, []);
 
 	const set = v => {
 		if (SUPPORTS_LOCAL_STORAGE) {


### PR DESCRIPTION
This fixes two things in the docs site:

1. The ThemeSwitcher was using the saved theme value from `localStorage` to render during initial page hydration, which causes a hydration mismatch when the theme is set to anything other than `"auto"` (the value we use during SSR).

    > To work around this, I added a third boolean argument to `useLocalStorage()` that causes it to return the provided `initial` value during the first render to ensure hydration matches SSR, then immediately self-update with the localStorage value if one was set.

2. It adds a little inline JS snippet to `<head>` that applies any saved theme from localStorage before CSS loads, which eliminates the flash-of-auto thing.

Preview of both changes:

https://user-images.githubusercontent.com/105127/115053287-f95b3600-9eac-11eb-9c33-617f91ac9000.mov

