### PR TITLE
Clear up cached module.s[ac]ss module mappings

### DIFF
--- a/.changeset/twenty-onions-serve.md
+++ b/.changeset/twenty-onions-serve.md
@@ -1,0 +1,5 @@
+---
+'wmr': minor
+---
+
+Fixes an issue that caused scss/sass modules to not be properly updated when new classes were added to the file.

--- a/packages/wmr/src/wmr-middleware.js
+++ b/packages/wmr/src/wmr-middleware.js
@@ -99,7 +99,7 @@ export default function wmrMiddleware(options) {
 		filename = filename.split(sep).join(posix.sep);
 
 		// Delete any generated CSS Modules mapping modules:
-		if (/\.module\.css$/.test(filename)) WRITE_CACHE.delete(filename + '.js');
+		if (/\.module\.(css|s[ac]ss)$/.test(filename)) WRITE_CACHE.delete(filename + '.js');
 
 		if (!pendingChanges.size) timeout = setTimeout(flushChanges, 60);
 


### PR DESCRIPTION
Currently `style.module.sass.js` and `style.module.scss.js` mapping get stale, so adding or changing class names in a sass-powered module file will not get acknowledged until full restart of wmr.