### PR TITLE
fix: Error messages by removing the backspace character from npm prefix

### DIFF
--- a/.changeset/big-dolls-hammer.md
+++ b/.changeset/big-dolls-hammer.md
@@ -1,0 +1,5 @@
+---
+'wmr': patch
+---
+
+Corrects output when referrencing module with npm prefix

--- a/packages/wmr/src/bundler.js
+++ b/packages/wmr/src/bundler.js
@@ -50,7 +50,7 @@ export async function bundleProd(options) {
 			// strip leading relative path
 			url = url.replace(/^\.\//g, '');
 			// replace internal npm prefix
-			url = url.replace(/^(\.?\.?\/)?[\b]npm\//, '@npm/');
+			url = url.replace(/^(\.?\.?\/)?npm\//, '@npm/');
 			return 'source:///' + url;
 		},
 		preferConst: true,
@@ -81,9 +81,9 @@ export async function bundleProd(options) {
 /** @type {import('rollup').GetManualChunk} */
 function extractNpmChunks(id, { getModuleIds, getModuleInfo }) {
 	const chunk = getModuleInfo(id);
-	if (/^[\b]npm\//.test(chunk.id)) {
+	if (/^npm\//.test(chunk.id)) {
 		// merge any modules that are only used by other modules:
-		const isInternalModule = chunk.importers.every(c => /^[\b]npm\//.test(c));
+		const isInternalModule = chunk.importers.every(c => /^npm\//.test(c));
 		if (isInternalModule) return null;
 
 		// create dedicated chunks for npm dependencies that are used in more than one place:
@@ -99,7 +99,7 @@ function extractNpmChunks(id, { getModuleIds, getModuleInfo }) {
 				name = dir;
 			}
 			// /chunks/@npm/NAME.[hash].js
-			return name.replace(/^[\b]npm\/((?:@[^/]+\/)?[^/]+)@[^/]+/, '@npm/$1');
+			return name.replace(/^npm\/((?:@[^/]+\/)?[^/]+)@[^/]+/, '@npm/$1');
 		}
 	}
 	return null;

--- a/packages/wmr/src/lib/output-utils.js
+++ b/packages/wmr/src/lib/output-utils.js
@@ -137,7 +137,7 @@ export function formatPath(path) {
 	if (typeof path === 'object') {
 		path = path.id;
 	}
-	if (path.startsWith('\b') || path.startsWith('\0')) {
+	if (path.startsWith('\0')) {
 		path = JSON.stringify(path);
 	}
 

--- a/packages/wmr/src/lib/plugins.js
+++ b/packages/wmr/src/lib/plugins.js
@@ -65,7 +65,7 @@ export function getPlugins(options) {
 		wmrPlugin({ hot: !production, preact: features.preact }),
 		fastCjsPlugin({
 			// Only transpile CommonJS in node_modules and explicit .cjs files:
-			include: /(?:^[\b]npm\/|[/\\]node_modules[/\\]|\.cjs$)/
+			include: /(^npm\/|[/\\]node_modules[/\\]|\.cjs$)/
 		}),
 		production && npmPlugin({ external: false }),
 		resolveExtensionsPlugin({

--- a/packages/wmr/src/plugins/copy-assets-plugin.js
+++ b/packages/wmr/src/plugins/copy-assets-plugin.js
@@ -39,7 +39,7 @@ export default function copyAssetsPlugin({ cwd = '.' } = {}) {
 				if (chunk.type === 'chunk') {
 					for (const f of chunk.referencedFiles) processed.add(f);
 					for (const f in chunk.modules) {
-						if (f[0] === '\0' || f[0] === '\b') continue;
+						if (f[0] === '\0') continue;
 						processed.add(relative(cwd, f));
 					}
 				} else if (chunk.name) {

--- a/packages/wmr/src/plugins/htm-plugin.js
+++ b/packages/wmr/src/plugins/htm-plugin.js
@@ -26,7 +26,7 @@ export default function htmPlugin({ include, production = true } = {}) {
 			if (!/\.[tj]sx?$/.test(filename)) return;
 
 			// skip internal modules
-			if (filename[0] === '\0' || filename[0] === '\b') return;
+			if (filename[0] === '\0') return;
 
 			if (include) {
 				const shouldTransform = typeof include === 'function' ? include(filename) : filename.match(include);

--- a/packages/wmr/src/plugins/npm-plugin/index.js
+++ b/packages/wmr/src/plugins/npm-plugin/index.js
@@ -12,7 +12,7 @@ import { debug, formatPath } from '../../lib/output-utils.js';
  * @param {boolean} [options.external] If `false`, resolved npm dependencies will be inlined by Rollup.
  * @returns {import('rollup').Plugin}
  */
-export default function npmPlugin({ publicPath = '/@npm', prefix = '\bnpm/', external = true } = {}) {
+export default function npmPlugin({ publicPath = '/@npm', prefix = 'npm/', external = true } = {}) {
 	const log = debug('npm:plugin');
 
 	return {

--- a/packages/wmr/src/plugins/sass-plugin.js
+++ b/packages/wmr/src/plugins/sass-plugin.js
@@ -58,7 +58,7 @@ export default function sassPlugin({ production = false, sourcemap = false } = {
 	return {
 		name: 'sass',
 		async transform(code, id) {
-			if (id[0] === '\0' || id[0] === '\b') return;
+			if (id[0] === '\0') return;
 			if (!/\.s[ac]ss$/.test(id)) return;
 
 			const result = await renderSass({

--- a/packages/wmr/src/plugins/sucrase-plugin.js
+++ b/packages/wmr/src/plugins/sucrase-plugin.js
@@ -21,7 +21,7 @@ export default function sucrasePlugin(opts = {}) {
 
 	function shouldProcess(id) {
 		const ch = id[0];
-		if (ch === '\0' || ch === '\b') return false;
+		if (ch === '\0') return false;
 		if (opts.typescript && /\.tsx?$/.test(id)) return true;
 		return include.length > 0 && include.some(pattern => id.match(pattern));
 	}

--- a/packages/wmr/src/plugins/unpkg-plugin.js
+++ b/packages/wmr/src/plugins/unpkg-plugin.js
@@ -2,8 +2,8 @@ import path from 'path';
 import fetch from 'node-fetch';
 import Cache from 'async-disk-cache';
 
-const PREFIX = '\bnpm/';
-const PREFIX_INTERNAL = '\bnpd/';
+const PREFIX = 'npm/';
+const PREFIX_INTERNAL = 'npd/';
 
 /**
  * Progressively load and cache individual dependency modules from unpkg.com
@@ -18,7 +18,7 @@ export default function unpkgPlugin({ resolutions = new Map(), publicPath = '@np
 		// if this is a submodule of a package entry, merge it into the entry:
 		if (filename.startsWith(PREFIX_INTERNAL)) {
 			const info = getModuleInfo(filename);
-			filename = info.importers.find(p => p.startsWith('\bnpm/')) || filename;
+			filename = info.importers.find(p => p.startsWith(PREFIX)) || filename;
 		}
 
 		let root = filename.substring(5);
@@ -31,9 +31,9 @@ export default function unpkgPlugin({ resolutions = new Map(), publicPath = '@np
 		name: 'unpkg-plugin',
 
 		async resolveId(s, from) {
-			if (/^[\b]np[md]\//.test(s)) s = s.substring(5);
+			if (/^np[md]\//.test(s)) s = s.substring(5);
 
-			if (from && /^[\b]np[md]\//.test(from)) from = from.substring(5);
+			if (from && /^np[md]\//.test(from)) from = from.substring(5);
 
 			const isRelativeToPackage = from && /^((?:@[^@/?]+\/)?[^@/?]+)(?:@[^/?]+)?(?:\/([^?]+))?(?:\?.*)?$/.test(from);
 			const isRelativeImport = /^\.?\.?(\/|$)/.test(s);
@@ -69,7 +69,7 @@ export default function unpkgPlugin({ resolutions = new Map(), publicPath = '@np
 		},
 
 		load(id) {
-			if (/^[\b]np[md]\//.test(id)) {
+			if (/^np[md]\//.test(id)) {
 				return unpkg(id.substring(5));
 			}
 		},
@@ -91,7 +91,7 @@ export default function unpkgPlugin({ resolutions = new Map(), publicPath = '@np
 			return {
 				...options,
 				manualChunks(filename, ctx) {
-					if (/^[\b]np[md]\//.test(filename)) {
+					if (/^np[md]\//.test(filename)) {
 						return manualChunks(filename, ctx);
 					}
 

--- a/packages/wmr/src/plugins/wmr/plugin.js
+++ b/packages/wmr/src/plugins/wmr/plugin.js
@@ -56,7 +56,7 @@ export default function wmrPlugin({ hot = true, preact } = {}) {
 		},
 		transform(code, id) {
 			const ch = id[0];
-			if (ch === '\0' || ch === '\b' || !/\.[tj]sx?$/.test(id)) return;
+			if (ch === '\0' || !/\.[tj]sx?$/.test(id)) return;
 			let hasHot = /(import\.meta\.hot|\$IMPORT_META_HOT\$)/.test(code);
 			let before = '';
 			let after = '';

--- a/packages/wmr/src/plugins/wmr/styles-plugin.js
+++ b/packages/wmr/src/plugins/wmr/styles-plugin.js
@@ -112,7 +112,7 @@ export default function wmrStylesPlugin({ cwd, hot, fullPath } = {}) {
 		},
 		async transform(source, id) {
 			if (!id.match(/\.(css|s[ac]ss)$/)) return;
-			if (id[0] === '\b' || id[0] === '\0') return;
+			if (id[0] === '\0') return;
 
 			const isIcss = /(composes:|:global|:local)/.test(source);
 			const isModular = /\.module\.(css|s[ac]ss)$/.test(id);

--- a/packages/wmr/src/wmr-middleware.js
+++ b/packages/wmr/src/wmr-middleware.js
@@ -149,11 +149,7 @@ export default function wmrMiddleware(options) {
 		let file = resolve(cwd, osPath);
 
 		// Rollup-style CWD-relative Unix-normalized path "id":
-		let id = relative(cwd, file)
-			.replace(/^\.\//, '')
-			.replace(/^[\0\b]/, '')
-			.split(sep)
-			.join(posix.sep);
+		let id = relative(cwd, file).replace(/^\.\//, '').replace(/^[\0]/, '').split(sep).join(posix.sep);
 
 		// add back any prefix if there was one:
 		file = prefix + file;


### PR DESCRIPTION
Preface: I'm not sure of the reason this was used to begin with, so it's possible I've missed something or that this isn't the best fix. Test suite passes, behavior seems right, but beyond that, quite unsure. 

## Summary

Corrects WMR output when referencing imports. For example, this message was pulled from the slack: `... Error: Could not loadnpm/call-bind@1.0.2/./ (imported bynpm/call-bind@1.0.2/callBound.js): ...`. The backspace character in the NPM prefix (`\bnpm`) would cause the output to be shown incorrectly like this (`loadnpm/...`, `bynpm/...`).

This PR simply removes the backspace character from the prefixes and the places it is checked for.

As far as I know, `PREFIX_INTERNAL` wasn't an issue / ever shown, but due to the shared regex between the prefixes, I changed both. 