### PR TITLE
refactor: Swapping out premove with fs.rmdir

### DIFF
--- a/.changeset/red-windows-dream.md
+++ b/.changeset/red-windows-dream.md
@@ -1,0 +1,5 @@
+---
+'wmr': patch
+---
+
+Replaces premove with native fs.rmdir

--- a/packages/wmr/package.json
+++ b/packages/wmr/package.json
@@ -133,7 +133,6 @@
 		"postcss": "^7.0.32",
 		"postcss-es6": "github:postcss/postcss#7.0.32",
 		"posthtml": "0.13.1",
-		"premove": "^3.0.1",
 		"prettier": "^2.0.5",
 		"puppeteer": "^3.3.0",
 		"resolve.exports": "^1.0.2",

--- a/packages/wmr/src/build.js
+++ b/packages/wmr/src/build.js
@@ -1,5 +1,5 @@
 import * as kl from 'kolorist';
-import { premove } from 'premove';
+import { promises as fs } from 'fs';
 import { bundleProd } from './bundler.js';
 import { bundleStats } from './lib/output-utils.js';
 import { prerender } from './lib/prerender.js';
@@ -17,7 +17,7 @@ export default async function build(options = {}) {
 
 	options = await normalizeOptions(options, 'build');
 
-	await premove(options.out);
+	await fs.rmdir(options.out, { recursive: true });
 
 	const bundleOutput = await bundleProd(options);
 


### PR DESCRIPTION
We originally added `premove` as the recursive removal option for `fs.rmdir()` didn't come out until Node 12.10 and the engine requirements were only set to >=12. 

But with #546 now upping that to 12.17, we can swap out `premove` with the native method. 