### PR TITLE
Add error overlay during development

### DIFF
--- a/.changeset/chilled-fishes-work.md
+++ b/.changeset/chilled-fishes-work.md
@@ -1,0 +1,5 @@
+---
+'wmr': minor
+---
+
+Render an error overlay into the page on build errors

--- a/packages/wmr/src/plugins/wmr/client.js
+++ b/packages/wmr/src/plugins/wmr/client.js
@@ -34,6 +34,7 @@ function connect(needsReload) {
 connect();
 
 let errorCount = 0;
+let hasErrorOverlay = false;
 
 const URL_SUFFIX = /\/(index\.html)?$/;
 
@@ -44,6 +45,11 @@ function handleMessage(e) {
 			window.location.reload();
 			break;
 		case 'update':
+			if (hasErrorOverlay) {
+				hasErrorOverlay = false;
+				const el = document.getElementById('wmr-error-overlay');
+				if (el) el.remove();
+			}
 			data.changes.forEach(url => {
 				url = resolve(url);
 				if (!mods.get(url)) {
@@ -96,6 +102,8 @@ function handleMessage(e) {
 			break;
 		case 'error': {
 			errorCount++;
+			hasErrorOverlay = true;
+			createErrorOverlay(data);
 			let msg = data.error;
 			if (data.codeFrame) {
 				msg += '\n' + data.codeFrame;
@@ -227,4 +235,168 @@ function updateStyleSheet(url) {
 			return true;
 		}
 	}
+}
+
+/**
+ * @type {<K extends keyof HTMLElementTagNameMap>(tag: K, attrs: any) => HTMLElementTagNameMap[K]}
+ */
+function createDom(tag, attrs) {
+	const el = document.createElement(tag);
+	for (const attr in attrs) {
+		const value = attrs[attr];
+		if (typeof value === 'function') {
+			el.addEventListener(attr.slice(2), value);
+		} else {
+			el.setAttribute(attr, value);
+		}
+	}
+	return el;
+}
+
+/**
+ *
+ * @param {{type: "error", error: string, codeFrame: string, stack: import('errorstacks').StackFrame[]}} data
+ */
+function createErrorOverlay(data) {
+	const existing = document.getElementById('wmr-error-overlay');
+	if (existing) existing.remove();
+
+	const outer = createDom('div', { id: 'wmr-error-overlay' });
+	const style = document.createElement('style');
+	style.textContent = `
+		#wmr-error-overlay {
+			--bg: #fff;
+			--bg-code-frame: rgb(255, 0, 32, 0.1);
+			--bg-active-line: #fbcecc;
+			--text: #222;
+			--text2: #444;
+			--title: #e84644;
+			--code: #333;
+			font-family: sans-serif;
+			line-height: 1.4;
+		}
+		#wmr-error-overlay * {
+			box-sizing: border-box;
+		}
+		
+		@media (prefers-color-scheme: dark) {
+			#wmr-error-overlay {
+				--bg-code-frame: rgba(251, 93, 113, 0.2);
+				--bg-active-line: #4f1919;
+				--bg: #353535;
+				--text: #f7f7f7;
+				--text2: #ddd;
+				--code: #fdd1d1;
+			}
+		}
+
+		.wmr-error-container {
+			position: fixed;
+			top: 0;
+			left: 0;
+			right: 0;
+			bottom: 0;
+			z-index: 9999;
+			color: var(--text);
+			background: var(--bg);
+		}
+
+		.wmr-error-close {
+			cursor: pointer;
+			position: absolute;
+			top: 1rem;
+			right: 1rem;
+		}
+
+		.wmr-error-inner {
+			max-width: 80ch;
+			padding: 4rem 1rem;
+			margin: 0 auto;
+		}
+
+		.wmr-error-title {
+			color: var(--title);
+			font-weight: normal;
+			font-size: 1.5rem;
+		}
+
+		.wmr-error-code-frame {
+			overflow: auto;
+			padding: 0.5rem;
+			background: var(--bg-code-frame);
+			color: var(--code);
+		}
+		.wmr-error-line {
+			padding: 0.25rem 0.5rem;
+		}
+		.wmr-error-active-line {
+			display: inline-block;
+			width: 100%;
+			background: var(--bg-active-line);
+		}
+
+		.wmr-error-detail {
+			cursor: pointer;
+			color: var(--text2);
+		}
+		.wmr-error-stack-frame {
+			padding: 0.5rem 0;
+		}
+		.wmr-error-stack-name {
+			color: var(--text);
+		}
+		.wmr-error-stack-loc {
+			color: var(--text2);
+			font-family: monospace;
+		}
+	`;
+	const overlay = createDom('div', { class: 'wmr-error-container' });
+	const close = createDom('button', {
+		class: 'wmr-error-close',
+		onclick: () => {
+			const dom = document.getElementById('wmr-error-overlay');
+			if (dom) dom.remove();
+		}
+	});
+	close.textContent = 'close';
+	const inner = createDom('div', { class: 'wmr-error-inner' });
+	overlay.append(close, inner);
+
+	const title = createDom('h1', { class: 'wmr-error-title' });
+	title.textContent = data.error;
+	inner.append(title);
+
+	const codeFrame = createDom('pre', { class: 'wmr-error-code-frame' });
+	const code = createDom('code', {});
+	codeFrame.append(code);
+
+	data.codeFrame.split('\n').forEach((line, i, arr) => {
+		const dom = createDom('span', { class: 'wmr-error-line' + (line.startsWith('>') ? ' wmr-error-active-line' : '') });
+		dom.textContent = line;
+		code.append(dom, i < arr.length - 1 ? '\n' : '');
+	});
+	inner.append(codeFrame);
+
+	outer.append(style, overlay);
+
+	const stackDetail = createDom('details', { class: 'wmr-error-detail' });
+	const stackSummary = createDom('summary', {});
+	stackSummary.textContent = `${data.stack.length} stack frames were collapsed.`;
+	stackDetail.append(stackSummary);
+
+	const frames = data.stack.map(frame => {
+		const container = createDom('div', { class: 'wmr-error-stack-frame' });
+		const name = createDom('div', { class: 'wmr-error-stack-name' });
+		name.textContent = frame.name;
+		const loc = createDom('div', { class: 'wmr-error-stack-loc' });
+		loc.textContent = `${frame.fileName}:${frame.line}:${frame.column}`;
+
+		container.append(name, loc);
+		return container;
+	});
+	stackDetail.append(...frames);
+
+	inner.append(stackDetail);
+
+	document.body.appendChild(outer);
 }

--- a/packages/wmr/src/plugins/wmr/client.js
+++ b/packages/wmr/src/plugins/wmr/client.js
@@ -245,15 +245,20 @@ function createErrorOverlay(data) {
 	if (errorOverlay) errorOverlay.remove();
 
 	const iframe = document.createElement('iframe');
-	iframe.style.cssText =
-		`position: fixed; top: 0; left: 0; bottom: 0; right: 0; z-index: 99999; width: 100%; height: 100%; border: none;`;
+	iframe.style.cssText = `position: fixed; top: 0; left: 0; bottom: 0; right: 0; z-index: 99999; width: 100%; height: 100%; border: none;`;
 
 	iframe.addEventListener('load', () => {
 		const doc = iframe.contentDocument;
 
+		/**
+		 * @param {string} tag
+		 * @param {Record<string, any> | null} props
+		 * @param {any[]} children
+		 * @returns {HTMLElement}
+		 */
 		function h(tag, props, ...children) {
 			props = props || {};
-			tag = tag.replace(/([.#])([^.#]+)/g, (s,g,i) => ((props[g=='.'?'className':'id']=i), ''));
+			tag = tag.replace(/([.#])([^.#]+)/g, (s, g, i) => ((props[g == '.' ? 'className' : 'id'] = i), ''));
 			const el = Object.assign(doc.createElement(tag), props);
 			el.append(...children);
 			return el;
@@ -340,34 +345,54 @@ function createErrorOverlay(data) {
 		`;
 
 		const lines = data.codeFrame.split('\n').reduce((lines, line, i, arr) => {
-			lines.push(h('span', {
-				className: 'line' + (line.startsWith('>') ? ' active-line' : '')
-			}, line));
+			lines.push(
+				h(
+					'span',
+					{
+						className: 'line' + (line.startsWith('>') ? ' active-line' : '')
+					},
+					line
+				)
+			);
 			if (i < arr.length - 1) lines.push('\n');
 			return lines;
-		}, []);
+		}, /** @type {any} */ ([]));
 
 		const frames = data.stack.map(frame =>
-			h('div.stack-frame', null,
+			h(
+				'div.stack-frame',
+				null,
 				h('div.stack-name', null, frame.name),
 				h('div.stack-loc', null, `${frame.fileName}:${frame.line}:${frame.column}`)
 			)
 		);
 
 		doc.body.append(
-			h('div#wmr-error-overlay', null,
+			h(
+				'div#wmr-error-overlay',
+				null,
 				h('style', null, STYLE),
-				h('div', null, 
-					h('button.close', {
-						onclick() {
-							errorOverlay.remove();
-							errorOverlay = null;
+				h(
+					'div',
+					null,
+					h(
+						'button.close',
+						{
+							onclick() {
+								errorOverlay.remove();
+								errorOverlay = null;
+							}
 						},
-					}, 'close'),
-					h('div.inner', null,
+						'close'
+					),
+					h(
+						'div.inner',
+						null,
 						h('h1.title', null, String(data.error)),
 						h('pre.code-frame', null, h('code', null, lines)),
-						h('details.detail', null,
+						h(
+							'details.detail',
+							null,
 							h('summary', null, `${data.stack.length} stack frames were collapsed.`),
 							...frames
 						)

--- a/packages/wmr/src/plugins/wmr/client.js
+++ b/packages/wmr/src/plugins/wmr/client.js
@@ -389,7 +389,7 @@ function createErrorOverlay(data) {
 						'div.inner',
 						null,
 						h('h1.title', null, String(data.error)),
-						h('pre.code-frame', null, h('code', null, lines)),
+						h('pre.code-frame', null, h('code', null, ...lines)),
 						h(
 							'details.detail',
 							null,

--- a/packages/wmr/src/plugins/wmr/client.js
+++ b/packages/wmr/src/plugins/wmr/client.js
@@ -302,7 +302,7 @@ function createErrorOverlay(data) {
 		}
 
 		.inner {
-			max-width: 80ch;
+			max-width: 48rem;
 			padding: 4rem 1rem;
 			margin: 0 auto;
 		}

--- a/packages/wmr/src/plugins/wmr/client.js
+++ b/packages/wmr/src/plugins/wmr/client.js
@@ -237,34 +237,45 @@ function updateStyleSheet(url) {
 	}
 }
 
-/**
- * @type {<K extends keyof HTMLElementTagNameMap>(tag: K, attrs: any) => HTMLElementTagNameMap[K]}
- */
-function createDom(tag, attrs) {
-	const el = document.createElement(tag);
-	for (const attr in attrs) {
-		const value = attrs[attr];
-		if (typeof value === 'function') {
-			el.addEventListener(attr.slice(2), value);
-		} else {
-			el.setAttribute(attr, value);
-		}
+// Listen for iframe close events
+window.addEventListener('message', message => {
+	if (message.data === 'wmr-close-error-overlay') {
+		document.getElementById('wmr-error-overlay')?.remove();
 	}
-	return el;
-}
+});
 
 /**
  *
  * @param {{type: "error", error: string, codeFrame: string, stack: import('errorstacks').StackFrame[]}} data
  */
 function createErrorOverlay(data) {
-	const existing = document.getElementById('wmr-error-overlay');
-	if (existing) existing.remove();
+	document.getElementById('wmr-error-overlay')?.remove();
 
-	const outer = createDom('div', { id: 'wmr-error-overlay' });
-	const style = document.createElement('style');
-	style.textContent = `
-		#wmr-error-overlay {
+	const iframe = document.createElement('iframe');
+	iframe.id = 'wmr-error-overlay';
+	iframe.setAttribute(
+		'style',
+		`position: fixed; top: 0; left: 0; bottom: 0; right: 0; z-index: 99999; width: 100%; height: 100%; border: none;`
+	);
+
+	iframe.addEventListener('load', () => {
+		function createDom(tag, attrs) {
+			const el = iframe.contentDocument?.createElement(tag);
+			for (const attr in attrs) {
+				const value = attrs[attr];
+				if (typeof value === 'function') {
+					el.addEventListener(attr.slice(2), value);
+				} else {
+					el.setAttribute(attr, value);
+				}
+			}
+			return el;
+		}
+
+		const outer = createDom('div', { id: 'wmr-error-overlay' });
+		const style = document.createElement('style');
+		style.textContent = `
+		:root {
 			--bg: #fff;
 			--bg-code-frame: rgb(255, 0, 32, 0.1);
 			--bg-active-line: #fbcecc;
@@ -274,13 +285,16 @@ function createErrorOverlay(data) {
 			--code: #333;
 			font-family: sans-serif;
 			line-height: 1.4;
+			color: var(--text);
+			background: var(--bg);
 		}
-		#wmr-error-overlay * {
+
+		* {
 			box-sizing: border-box;
 		}
 		
 		@media (prefers-color-scheme: dark) {
-			#wmr-error-overlay {
+			:root {
 				--bg-code-frame: rgba(251, 93, 113, 0.2);
 				--bg-active-line: #4f1919;
 				--bg: #353535;
@@ -290,113 +304,105 @@ function createErrorOverlay(data) {
 			}
 		}
 
-		.wmr-error-container {
-			position: fixed;
-			top: 0;
-			left: 0;
-			right: 0;
-			bottom: 0;
-			z-index: 9999;
-			color: var(--text);
-			background: var(--bg);
-		}
-
-		.wmr-error-close {
+		.close {
 			cursor: pointer;
 			position: absolute;
 			top: 1rem;
 			right: 1rem;
 		}
 
-		.wmr-error-inner {
+		.inner {
 			max-width: 80ch;
 			padding: 4rem 1rem;
 			margin: 0 auto;
 		}
 
-		.wmr-error-title {
+		.title {
 			color: var(--title);
 			font-weight: normal;
 			font-size: 1.5rem;
 		}
 
-		.wmr-error-code-frame {
+		.code-frame {
 			overflow: auto;
 			padding: 0.5rem;
 			background: var(--bg-code-frame);
 			color: var(--code);
 		}
-		.wmr-error-line {
+		.line {
 			padding: 0.25rem 0.5rem;
 		}
-		.wmr-error-active-line {
+		.active-line {
 			display: inline-block;
 			width: 100%;
 			background: var(--bg-active-line);
 		}
 
-		.wmr-error-detail {
+		.detail {
 			cursor: pointer;
 			color: var(--text2);
 		}
-		.wmr-error-stack-frame {
+		.stack-frame {
 			padding: 0.5rem 0;
 		}
-		.wmr-error-stack-name {
+		.stack-name {
 			color: var(--text);
 		}
-		.wmr-error-stack-loc {
+		.stack-loc {
 			color: var(--text2);
 			font-family: monospace;
 		}
 	`;
-	const overlay = createDom('div', { class: 'wmr-error-container' });
-	const close = createDom('button', {
-		class: 'wmr-error-close',
-		onclick: () => {
-			const dom = document.getElementById('wmr-error-overlay');
-			if (dom) dom.remove();
-		}
+		const overlay = createDom('div', {});
+		const close = createDom('button', {
+			class: 'close',
+			onclick: () => {
+				window.postMessage('wmr-close-error-overlay', '*');
+			}
+		});
+		close.textContent = 'close';
+		const inner = createDom('div', { class: 'inner' });
+		overlay.append(close, inner);
+
+		const title = createDom('h1', { class: 'title' });
+		title.textContent = data.error;
+		inner.append(title);
+
+		const codeFrame = createDom('pre', { class: 'code-frame' });
+		const code = createDom('code', {});
+		codeFrame.append(code);
+
+		data.codeFrame.split('\n').forEach((line, i, arr) => {
+			const dom = createDom('span', {
+				class: 'line' + (line.startsWith('>') ? ' active-line' : '')
+			});
+			dom.textContent = line;
+			code.append(dom, i < arr.length - 1 ? '\n' : '');
+		});
+		inner.append(codeFrame);
+
+		outer.append(style, overlay);
+
+		const stackDetail = createDom('details', { class: 'detail' });
+		const stackSummary = createDom('summary', {});
+		stackSummary.textContent = `${data.stack.length} stack frames were collapsed.`;
+		stackDetail.append(stackSummary);
+
+		const frames = data.stack.map(frame => {
+			const container = createDom('div', { class: 'stack-frame' });
+			const name = createDom('div', { class: 'stack-name' });
+			name.textContent = frame.name;
+			const loc = createDom('div', { class: 'stack-loc' });
+			loc.textContent = `${frame.fileName}:${frame.line}:${frame.column}`;
+
+			container.append(name, loc);
+			return container;
+		});
+		stackDetail.append(...frames);
+
+		inner.append(stackDetail);
+		iframe.contentDocument?.body.appendChild(outer);
 	});
-	close.textContent = 'close';
-	const inner = createDom('div', { class: 'wmr-error-inner' });
-	overlay.append(close, inner);
 
-	const title = createDom('h1', { class: 'wmr-error-title' });
-	title.textContent = data.error;
-	inner.append(title);
-
-	const codeFrame = createDom('pre', { class: 'wmr-error-code-frame' });
-	const code = createDom('code', {});
-	codeFrame.append(code);
-
-	data.codeFrame.split('\n').forEach((line, i, arr) => {
-		const dom = createDom('span', { class: 'wmr-error-line' + (line.startsWith('>') ? ' wmr-error-active-line' : '') });
-		dom.textContent = line;
-		code.append(dom, i < arr.length - 1 ? '\n' : '');
-	});
-	inner.append(codeFrame);
-
-	outer.append(style, overlay);
-
-	const stackDetail = createDom('details', { class: 'wmr-error-detail' });
-	const stackSummary = createDom('summary', {});
-	stackSummary.textContent = `${data.stack.length} stack frames were collapsed.`;
-	stackDetail.append(stackSummary);
-
-	const frames = data.stack.map(frame => {
-		const container = createDom('div', { class: 'wmr-error-stack-frame' });
-		const name = createDom('div', { class: 'wmr-error-stack-name' });
-		name.textContent = frame.name;
-		const loc = createDom('div', { class: 'wmr-error-stack-loc' });
-		loc.textContent = `${frame.fileName}:${frame.line}:${frame.column}`;
-
-		container.append(name, loc);
-		return container;
-	});
-	stackDetail.append(...frames);
-
-	inner.append(stackDetail);
-
-	document.body.appendChild(outer);
+	document.body.appendChild(iframe);
 }

--- a/packages/wmr/src/start.js
+++ b/packages/wmr/src/start.js
@@ -9,6 +9,7 @@ import { setCwd } from './plugins/npm-plugin/registry.js';
 import { formatBootMessage, debug } from './lib/output-utils.js';
 import { watch } from './lib/fs-watcher.js';
 import { injectWmr } from './lib/transform-html.js';
+import { parseStackTrace } from 'errorstacks';
 
 /**
  * @typedef OtherOptions
@@ -93,7 +94,8 @@ async function bootServer(options, configWatchFiles) {
 			app.ws.broadcast({
 				type: 'error',
 				error: err.clientMessage || err.message,
-				codeFrame: kl.stripColors(err.codeFrame)
+				codeFrame: kl.stripColors(err.codeFrame),
+				stack: parseStackTrace(err.stack)
 			});
 		}
 	}


### PR DESCRIPTION
This PR adds a simple error overlay that is displayed on build errors.

Light:

<img width="675" alt="Screenshot 2021-04-25 at 15 00 55" src="https://user-images.githubusercontent.com/1062408/115994705-6327be00-a5d8-11eb-8065-f75293ebd959.png">

Dark:

<img width="886" alt="Screenshot 2021-04-25 at 19 03 14" src="https://user-images.githubusercontent.com/1062408/116002214-ece78380-a5f8-11eb-9ee8-ef1603c0c041.png">

