### PR TITLE
Fix crash when passing array children to preact-iso

### DIFF
--- a/.changeset/thirty-poets-fry.md
+++ b/.changeset/thirty-poets-fry.md
@@ -1,0 +1,5 @@
+---
+'preact-iso': patch
+---
+
+Fix crash when passing dynamic arrays as children. This was caused by missing children normalization.

--- a/packages/preact-iso/router.js
+++ b/packages/preact-iso/router.js
@@ -1,4 +1,4 @@
-import { h, createContext, cloneElement } from 'preact';
+import { h, createContext, cloneElement, toChildArray } from 'preact';
 import { useContext, useMemo, useReducer, useEffect, useLayoutEffect, useRef } from 'preact/hooks';
 
 let push;
@@ -106,7 +106,7 @@ export function Router(props) {
 		prev.current = cur.current;
 
 		let p, d, m;
-		[].concat(props.children || []).some(vnode => {
+		toChildArray(props.children).some(vnode => {
 			const matches = exec(path, vnode.props.path, (m = { path, query }));
 			if (matches) return (p = cloneElement(vnode, m));
 			if (vnode.props.default) d = cloneElement(vnode, m);

--- a/packages/preact-iso/test/router.test.js
+++ b/packages/preact-iso/test/router.test.js
@@ -399,4 +399,38 @@ describe('Router', () => {
 
 		pushState.mockRestore();
 	});
+
+	it('should normalize children', async () => {
+		let loc;
+		const pushState = jest.spyOn(history, 'pushState');
+		const Route = jest.fn(() => html`<a href="/foo#foo">foo</a>`);
+
+		const routes = ['/foo', '/bar'];
+		render(
+			html`
+				<${LocationProvider}>
+					<${Router}>
+						${routes.map(route => html`<${Route} path=${route} />`)}
+						<${Route} default />
+					<//>
+					<${() => {
+						loc = useLocation();
+					}} />
+				<//>
+			`,
+			scratch
+		);
+
+		expect(Route).toHaveBeenCalledTimes(1);
+		Route.mockClear();
+		await sleep(20);
+
+		scratch.querySelector('a[href="/foo#foo"]').click();
+		await sleep(100);
+		expect(Route).toHaveBeenCalledTimes(1);
+		expect(loc).toMatchObject({ url: '/foo#foo', path: '/foo' });
+		expect(pushState).toHaveBeenCalled();
+
+		pushState.mockRestore();
+	});
 });


### PR DESCRIPTION
The following snippet lead to a crash:

```jsx
<Router>
  <Route path="/" />
  {["a", "b"].map(x => <Route path={`/${x}`} />}
  {condition && <Route path="/boof" />}
</Route>
```

There error was caused because we didn't normalize children at all.