### PR TITLE
Changed recommendation to use .mjs in readme.md

### DIFF
--- a/packages/nomodule-plugin/README.md
+++ b/packages/nomodule-plugin/README.md
@@ -7,7 +7,7 @@ New browsers get the new stuff, old browsers get the old stuff.
 
 ## Usage
 
-Add this to your `wmr.config.js`:
+Add this to your `wmr.config.mjs`:
 
 ```js
 import nomodule from '@wmrjs/nomodule';


### PR DESCRIPTION
Because with `wmr.config.mjs` now results `SyntaxError: Cannot use import statement outside a module`
```
❯ mv ./wmr.config.mjs ./wmr.config.js

❯ npm run build

> @ build /Users/jt3k/work/sigma-aa/active-age/creditpotential
> wmr build --prerender

(node:49904) Warning: To load an ES module, set "type": "module" in the package.json or use the .mjs extension.
(Use `node --trace-warnings ...` to show where the warning was created)
/Users/jt3k/work/sigma-aa/active-age/creditpotential/wmr.config.js:1
import nomodule from '@wmrjs/nomodule';
^^^^^^

SyntaxError: Cannot use import statement outside a module
    at wrapSafe (internal/modules/cjs/loader.js:979:16)
    at Module._compile (internal/modules/cjs/loader.js:1027:27)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1092:10)
    at Module.load (internal/modules/cjs/loader.js:928:32)
    at Function.Module._load (internal/modules/cjs/loader.js:769:14)
    at ModuleWrap.<anonymous> (internal/modules/esm/translators.js:199:29)
    at ModuleJob.run (internal/modules/esm/module_job.js:152:23)
    at async Loader.import (internal/modules/esm/loader.js:166:24)
    at async kJe (/Users/jt3k/work/sigma-aa/active-age/creditpotential/node_modules/wmr/wmr.cjs:2:2446119)
    at async PJe (/Users/jt3k/work/sigma-aa/active-age/creditpotential/node_modules/wmr/wmr.cjs:2:2447457)

Failed to load wmr.config.js
SyntaxError: Cannot use import statement outside a module
TypeError [ERR_INVALID_ARG_TYPE]: The "id" argument must be of type string. Received an instance of URL
    at kJe (/Users/jt3k/work/sigma-aa/active-age/creditpotential/node_modules/wmr/wmr.cjs:2:2446268)
    at async PJe (/Users/jt3k/work/sigma-aa/active-age/creditpotential/node_modules/wmr/wmr.cjs:2:2447457)

npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! @ build: `wmr build --prerender`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the @ build script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/jt3k/.npm/_logs/2021-04-29T10_10_41_649Z-debug.log
```
