### PR TITLE
Fix missing build errors in terminal output

### DIFF
--- a/.changeset/breezy-dolphins-retire.md
+++ b/.changeset/breezy-dolphins-retire.md
@@ -1,0 +1,5 @@
+---
+'wmr': patch
+---
+
+Fix missing build errors in terminal

--- a/packages/wmr/src/cli.js
+++ b/packages/wmr/src/cli.js
@@ -62,12 +62,22 @@ function run(p) {
 	p.catch(catchException);
 }
 
+/**
+ * @param {Error} err
+ */
 function catchException(err) {
-	const text = (err.stack && err.stack.split('\n')[0]) || err.message || err + '';
-	const stack = errorstacks
-		.parseStackTrace(err.stack)
-		.map(frame => frame.raw)
-		.join('\n');
+	let text = '';
+	let stack = '';
+	if (err.stack) {
+		const formattedStack = errorstacks.parseStackTrace(err.stack);
+		if (formattedStack.length > 0) {
+			const idx = err.stack.indexOf(formattedStack[0].raw);
+			text = err.stack.slice(0, idx).trim() + '\n';
+			stack = formattedStack.map(frame => frame.raw).join('\n');
+		}
+	}
+
+	if (!text) text = err.message || err + '';
 
 	process.stderr.write(`\n${kl.red(text)}\n${stack ? kl.dim(stack + '\n\n') : ''}`);
 	process.exit(1);

--- a/packages/wmr/test/fixtures/script-type/public/foo.js
+++ b/packages/wmr/test/fixtures/script-type/public/foo.js
@@ -1,0 +1,1 @@
+export const foo = 'it works';

--- a/packages/wmr/test/fixtures/script-type/public/index.html
+++ b/packages/wmr/test/fixtures/script-type/public/index.html
@@ -1,0 +1,1 @@
+<script src="./index.js"></script>

--- a/packages/wmr/test/fixtures/script-type/public/index.js
+++ b/packages/wmr/test/fixtures/script-type/public/index.js
@@ -1,0 +1,3 @@
+import { foo } from './foo.js';
+
+document.getElementById('root').textContent = foo;

--- a/packages/wmr/test/production.test.js
+++ b/packages/wmr/test/production.test.js
@@ -1,6 +1,6 @@
 import path from 'path';
 import { promises as fs } from 'fs';
-import { setupTest, teardown, runWmr, loadFixture, serveStatic } from './test-helpers.js';
+import { setupTest, teardown, runWmr, loadFixture, serveStatic, withLog } from './test-helpers.js';
 import { printCoverage, analyzeTrace } from './tracing-helpers.js';
 
 jest.setTimeout(30000);
@@ -41,6 +41,18 @@ describe('production', () => {
 		});
 
 		expect(await env.page.content()).toMatch(/foobarbaz/);
+	});
+
+	it('should throw error on missing module type', async () => {
+		await loadFixture('script-type', env);
+		instance = await runWmr(env.tmp.path, 'build');
+		await withLog(instance.output, async () => {
+			const code = await instance.done;
+			expect(code).toEqual(1);
+
+			const log = instance.output.join('\n');
+			expect(log).toMatch(/No module scripts were found/);
+		});
 	});
 
 	it('should allow overwriting url loader', async () => {

--- a/packages/wmr/test/test-helpers.js
+++ b/packages/wmr/test/test-helpers.js
@@ -218,6 +218,20 @@ export async function waitForNotMessage(haystack, message, timeout = 1000) {
 }
 
 /**
+ * Print haystack when `fn` throws
+ * @param {string[]} haystack
+ * @param {() => any} fn
+ */
+export async function withLog(haystack, fn) {
+	try {
+		await fn();
+	} catch (err) {
+		console.log(haystack);
+		throw err;
+	}
+}
+
+/**
  * @param {WmrInstance} instance
  * @param {string} urlPath
  * @returns {Promise<{status?: number, body: string, res: import('http').IncomingMessage }>}


### PR DESCRIPTION
This PR fixes a regression introduced in #561. There the logic assumed that the full error message would always be the first line of `error.stack`.

This is not universally true and most errors thrown by us spans multiple lines by default. With our previous logic we only showed a tiny part of the message.

Before:

![image](https://user-images.githubusercontent.com/1062408/116606303-ca26d900-a930-11eb-9b65-278854e548d3.png)

After:

![image](https://user-images.githubusercontent.com/1062408/116606335-d7dc5e80-a930-11eb-9165-2b3cbe6bb53a.png)


The new logic leverages our stack trace parser to determine the offset of when it finds an actual location and assumes that everything before that must be the message.

Added a test to catch that in the future.