### PR TITLE
Don't partially indent code frame on html warnings

### DIFF
--- a/.changeset/four-starfishes-begin.md
+++ b/.changeset/four-starfishes-begin.md
@@ -1,0 +1,5 @@
+---
+'wmr': patch
+---
+
+Fix partially indented code frame on html warnings

--- a/packages/wmr/src/plugins/html-entries-plugin.js
+++ b/packages/wmr/src/plugins/html-entries-plugin.js
@@ -79,7 +79,7 @@ export default function htmlEntriesPlugin({ cwd, publicDir, publicPath } = {}) {
 								yellow(` <script src="${url}"> is missing type="module".\n`) +
 								white(`${dim('>')} Only module scripts are handled by WMR.\n`) +
 								white(dim('> ' + yellow(entryId) + ': ')) +
-								(frame ? white(frame) : '')
+								(frame ? '\n' + white(frame) : '')
 						);
 						return null;
 					}


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/1062408/116612739-2f31fd00-a938-11eb-8b3d-27292c6108fb.png)

After:

![image](https://user-images.githubusercontent.com/1062408/116612683-22150e00-a938-11eb-8a3e-4abba7cfdc8f.png)
