### PR TITLE
Update preact/iso TypeScript types

### DIFF
--- a/.changeset/fluffy-lamps-smile.md
+++ b/.changeset/fluffy-lamps-smile.md
@@ -1,0 +1,5 @@
+---
+"preact-iso": patch
+---
+
+Update preact/iso TypeScript types

--- a/packages/preact-iso/index.d.ts
+++ b/packages/preact-iso/index.d.ts
@@ -1,4 +1,4 @@
 export { default as prerender } from './prerender';
-export { Router, LocationProvider, useLocation } from './router';
+export * from './router';
 export { default as lazy, ErrorBoundary } from './lazy';
 export { default as hydrate } from './hydrate';

--- a/packages/preact-iso/index.d.ts
+++ b/packages/preact-iso/index.d.ts
@@ -1,4 +1,4 @@
 export { default as prerender } from './prerender';
-export { Router, LocationProvider, useLoc, useLocation } from './router';
+export { Router, LocationProvider, useLocation } from './router';
 export { default as lazy, ErrorBoundary } from './lazy';
 export { default as hydrate } from './hydrate';

--- a/packages/preact-iso/router.d.ts
+++ b/packages/preact-iso/router.d.ts
@@ -2,7 +2,11 @@ import { AnyComponent, FunctionComponent, VNode } from 'preact';
 
 export const LocationProvider: FunctionComponent;
 
-export function Router(props: { onLoadEnd?: (url: string) => void; onLoadStart?: (url: string) => void; children?: VNode[] }): VNode;
+export function Router(props: {
+	onLoadEnd?: (url: string) => void;
+	onLoadStart?: (url: string) => void;
+	children?: VNode[];
+}): VNode;
 
 interface LocationHook {
 	url: string;
@@ -20,7 +24,7 @@ interface RoutableProps {
 }
 
 export interface RouteProps<Props> extends RoutableProps {
-	  component: AnyComponent<Props>;
+	component: AnyComponent<Props>;
 }
 
 export function Route<Props>(props: RouteProps<Props> & Partial<Props>): VNode;

--- a/packages/preact-iso/router.d.ts
+++ b/packages/preact-iso/router.d.ts
@@ -16,7 +16,11 @@ interface LocationHook {
 }
 export const useLocation: () => LocationHook;
 
-export const useRoute: () => { [key: string]: string };
+export const useRoute: () => {
+	path: string;
+	query: Record<string, string>;
+	params: Record<string, string>;
+};
 
 interface RoutableProps {
 	path?: string;


### PR DESCRIPTION
- Fix missing `useRoute` and `RouterProps` in types
- Strongly type return value of `useRoute`
- Remove deprecated `useLoc` type