### PR TITLE
Fix bare specifiers always rewritten as npm packages

### DIFF
--- a/.changeset/sweet-tables-impress.md
+++ b/.changeset/sweet-tables-impress.md
@@ -1,0 +1,5 @@
+---
+'wmr': patch
+---
+
+Allow plugins to pick any specifier for virtual modules

--- a/packages/wmr/test/fixtures.test.js
+++ b/packages/wmr/test/fixtures.test.js
@@ -94,6 +94,14 @@ describe('fixtures', () => {
 		expect(text).toMatch(/fallback: \/foo\.svg\?asset/);
 	});
 
+	it('should support virtual ids', async () => {
+		await loadFixture('virtual-id', env);
+		instance = await runWmrFast(env.tmp.path);
+		const text = await getOutput(env, instance);
+
+		expect(text).toMatch('it works');
+	});
+
 	describe('empty', () => {
 		it('should print warning for missing index.html file in public dir', async () => {
 			await loadFixture('empty', env);

--- a/packages/wmr/test/fixtures/virtual-id/public/index.html
+++ b/packages/wmr/test/fixtures/virtual-id/public/index.html
@@ -1,0 +1,2 @@
+<h1>it doesn't work</div>
+<script src="./index.js" type="module"></script>

--- a/packages/wmr/test/fixtures/virtual-id/public/index.js
+++ b/packages/wmr/test/fixtures/virtual-id/public/index.js
@@ -1,0 +1,4 @@
+import { it } from 'virtual-id';
+import { works } from '@virtual-id';
+
+document.querySelector('h1').textContent = it + ' ' + works;

--- a/packages/wmr/test/fixtures/virtual-id/wmr.config.mjs
+++ b/packages/wmr/test/fixtures/virtual-id/wmr.config.mjs
@@ -1,0 +1,24 @@
+export default function () {
+	const ID = 'virtual-id';
+	const ID2 = '@virtual-id';
+
+	return {
+		plugins: [
+			{
+				name: 'virtual-id-plugin',
+				resolveId(id) {
+					if (id === ID || id === ID2) {
+						return id;
+					}
+				},
+				load(id) {
+					if (id === ID) {
+						return `export const it = "it"`;
+					} else if (id === ID2) {
+						return `export const works = "works"`;
+					}
+				}
+			}
+		]
+	};
+}

--- a/packages/wmr/test/production.test.js
+++ b/packages/wmr/test/production.test.js
@@ -90,6 +90,23 @@ describe('production', () => {
 		expect(stats.join('\n')).toMatch(/img\..*\.jpg/);
 	});
 
+	it('should support virtual ids', async () => {
+		await loadFixture('virtual-id', env);
+		instance = await runWmr(env.tmp.path, 'build');
+		const code = await instance.done;
+		expect(code).toEqual(0);
+
+		const { address, stop } = serveStatic(path.join(env.tmp.path, 'dist'));
+		cleanup.push(stop);
+
+		await env.page.goto(address, {
+			waitUntil: ['networkidle0', 'load']
+		});
+
+		const text = await env.page.content();
+		expect(text).toMatch(/it works/);
+	});
+
 	describe('CSS', () => {
 		it('should resolve CSS imports', async () => {
 			await loadFixture('css-imports', env);


### PR DESCRIPTION
This PR allows plugins to pick any name for a virtual module instead of having to dance around our npm or prefix detection logic. They can now just be named `my-virtual-module` or `@my-virtual-module` for example and it works out of the box. This is the main friction point I run into over and over whenever I play with custom plugins.

```js
{
  name: 'my-plugin',
  resolveId(id) {
    if (id === 'my-module') {
      return id;
    }
  },
  load(id) {
    if (id === 'my-module') {
      return `export const foo = 42`;
    }
  }
}
```

The detection is based on the return value of `load()`. In the case of virtual modules we'd return a non-null result, since plugins neat to load that. When the return value is `null` we therefore know that the passed `id` can't be a virtual module and therefore must refer to an npm package. Basically this is the same detection that rollup does internally.

There is one minor tradeoff to this approach though: Now any direct dependenants of a module are eagerly loaded. So if there is a module with 1000 conditional lazy imports we'd start loading all of those instead of only the one that the application requested. This happens because we can't know if a module is virtual or not before calling `.load(id)`.

An alternative to the implementation proposed here could be to skip trying to detect if a module is virtual or not until it is request. We currently do that detection logic when processing imports. So instead of rewriting paths to `/@npm/my-module`, we'd put them behind a generic prefix and resolve it to either a virtual module or npm package on load. It seems more elegant on paper and something we should definitely do in the long run, but I don't have a good grasp of the necessary changes required for that yet.