### PR TITLE
preact-iso: fix ErrorBoundary pushing object into commit queue

### DIFF
--- a/.changeset/afraid-goats-occur.md
+++ b/.changeset/afraid-goats-occur.md
@@ -1,0 +1,5 @@
+---
+"preact-iso": patch
+---
+
+preact-iso: fix ErrorBoundary pushing invalid callback into commit queue

--- a/packages/preact-iso/lazy.js
+++ b/packages/preact-iso/lazy.js
@@ -39,5 +39,5 @@ export function ErrorBoundary(props) {
 }
 
 function childDidSuspend(err) {
-	err.then(Object).then(this.forceUpdate.bind(this));
+	err.then(() => this.forceUpdate());
 }


### PR DESCRIPTION
This prevents ErrorBoundary from pushing objects into the commit queue, which only handles functions (it tries to call `item.call(component)` where `item` is an object.