### PR TITLE
Show all generated files on build

### DIFF
--- a/.changeset/tiny-phones-mate.md
+++ b/.changeset/tiny-phones-mate.md
@@ -1,0 +1,5 @@
+---
+'wmr': patch
+---
+
+Fix missing generated files on cli output on build

--- a/packages/wmr/src/build.js
+++ b/packages/wmr/src/build.js
@@ -1,5 +1,6 @@
 import * as kl from 'kolorist';
 import { promises as fs } from 'fs';
+import path from 'path';
 import { bundleProd } from './bundler.js';
 import { bundleStats } from './lib/output-utils.js';
 import { prerender } from './lib/prerender.js';
@@ -21,8 +22,8 @@ export default async function build(options = {}) {
 
 	const bundleOutput = await bundleProd(options);
 
-	const stats = bundleStats(bundleOutput);
-	process.stdout.write(kl.bold(`Wrote ${stats.totalText} to disk:`) + stats.assetsText + '\n');
+	const stats = bundleStats(bundleOutput, path.relative(options.root, options.out));
+	process.stdout.write(kl.bold(`\nWrote ${stats.totalText} to disk:`) + stats.assetsText + '\n');
 
 	if (!options.prerender) return;
 

--- a/packages/wmr/test/production.test.js
+++ b/packages/wmr/test/production.test.js
@@ -77,6 +77,19 @@ describe('production', () => {
 		expect(text).toMatch(/fallback: \/assets\/foo\..*\.svg/);
 	});
 
+	it('should show all generated files in cli output', async () => {
+		await loadFixture('file-import', env);
+		instance = await runWmr(env.tmp.path, 'build');
+		const code = await instance.done;
+		const output = instance.output;
+		console.log(output);
+
+		expect(code).toEqual(0);
+
+		const stats = output.slice(output.findIndex(line => /Wrote.*to disk/.test(line)));
+		expect(stats.join('\n')).toMatch(/img\..*\.jpg/);
+	});
+
 	describe('import.meta.env', () => {
 		it('should support process.env.NODE_ENV', async () => {
 			await loadFixture('import-meta-env', env);


### PR DESCRIPTION
I'm always unsure if the generated files on build are as expected without looking manually, as our output filters out all non-css assets.

This PR changes that, but keeps the group intact, so that code files are at the top.

Before:

<img width="480" alt="Screenshot 2021-05-02 at 00 14 06" src="https://user-images.githubusercontent.com/1062408/116796286-a227a900-aadb-11eb-85ec-f37923f1a6e3.png">

After:

<img width="427" alt="Screenshot 2021-05-02 at 00 05 49" src="https://user-images.githubusercontent.com/1062408/116796291-a94eb700-aadb-11eb-8e74-f9dd1364da57.png">
