### PR TITLE
Prerendering: Remove incomplete fake document

### DIFF
--- a/.changeset/chatty-scissors-protect.md
+++ b/.changeset/chatty-scissors-protect.md
@@ -1,0 +1,30 @@
+---
+"wmr": major
+---
+
+Rework prerendering API for tags in `document.head`. Previously the API is based on a subset of the actual `document.head` object. But in supplying a `document` global we rendered third party library checks invalid which usually use a variant of `typeof document === "undefined"` to determine if they're in a server environment or not. Since every library uses a different subset of the DOM API, it's impossible to support everyone. Instead using the server code paths of those libraries is a much more reliable approach.
+
+Any tags that should land in `document.head` can be added to the return value of the `prerender` function:
+
+```js
+export async function prerender(data) {
+  // ...do your prerendering here
+  
+  return {
+    // The string that is put inside <body>
+    html: "<h1>Hello world</h1>",
+    head: {
+      // sets document.title
+      title: "My Cool Title",
+      // Sets the lang attribute on the <html> element
+      lang: "en",
+      // Any element you want to put into document.head
+      elements: [
+        { type: "link", props: { rel: "stylesheet", href: "/path/to/my/style.css" } },
+        { type: "meta", props: { property: "og:title", content: "Become an SEO Expert" } }
+      ]
+    }
+  }
+}
+
+```

--- a/docs/package.json
+++ b/docs/package.json
@@ -11,7 +11,8 @@
 	"dependencies": {
 		"preact": "^10.5.13",
 		"preact-iso": "*",
-		"preact-markup": "^2.1.1"
+		"preact-markup": "^2.1.1",
+		"hoofd": "^1.2.2"
 	},
 	"devDependencies": {
 		"@wmrjs/directory-import": "*",

--- a/docs/public/components/meta.js
+++ b/docs/public/components/meta.js
@@ -1,10 +1,7 @@
-let meta;
+import { useTitle, useMeta } from 'hoofd/preact';
+
 export default function Meta({ title, description }) {
-	document.title = 'WMR: ' + title;
-	if (!meta || !meta.parentNode) {
-		meta = document.createElement('meta');
-		meta.name = 'description';
-		meta.content = description;
-		document.head.appendChild(meta);
-	}
+	useTitle('WMR: ' + title);
+	useMeta({ name: 'description', content: description });
+	return null;
 }

--- a/docs/public/prerender.js
+++ b/docs/public/prerender.js
@@ -19,5 +19,13 @@ export async function prerender(vnode) {
 		await init();
 	}
 	const res = await render(vnode);
-	return { ...res, head: toStatic() };
+
+	const head = toStatic();
+	const elements = new Set([
+		...head.links.map(props => ({ type: 'link', props })),
+		...head.metas.map(props => ({ type: 'meta', props })),
+		...head.scripts.map(props => ({ type: 'script', props }))
+	]);
+
+	return { ...res, head: { lang: head.lang, title: head.title, elements } };
 }

--- a/docs/public/prerender.js
+++ b/docs/public/prerender.js
@@ -1,4 +1,5 @@
 import render from 'preact-iso/prerender';
+import { toStatic } from 'hoofd/preact';
 
 let initialized = false;
 // install a fetch+DOMParser "polyfills" for Node (used by content & <Markup>)
@@ -17,5 +18,6 @@ export async function prerender(vnode) {
 		initialized = true;
 		await init();
 	}
-	return await render(vnode);
+	const res = await render(vnode);
+	return { ...res, head: toStatic() };
 }

--- a/examples/demo/package.json
+++ b/examples/demo/package.json
@@ -24,6 +24,7 @@
 	},
 	"dependencies": {
 		"preact": "^10.5.13",
-		"preact-iso": "*"
+		"preact-iso": "*",
+		"hoofd": "^1.2.2"
 	}
 }

--- a/examples/demo/public/header.tsx
+++ b/examples/demo/public/header.tsx
@@ -14,6 +14,7 @@ export default function Header() {
 				<a href="/env">Env</a>
 				<a href="/json">JSON</a>
 				<a href="/error">Error</a>
+				<a href="/meta-tags">Meta-Tags</a>
 			</nav>
 			<label>
 				URL:

--- a/examples/demo/public/index.tsx
+++ b/examples/demo/public/index.tsx
@@ -59,7 +59,20 @@ export async function prerender(data) {
 	const res = await render(<App {...data} />);
 
 	const head = toStatic();
-	return { ...res, head };
+	const elements = new Set([
+		...head.links.map(props => ({ type: 'link', props })),
+		...head.metas.map(props => ({ type: 'meta', props })),
+		...head.scripts.map(props => ({ type: 'script', props }))
+	]);
+
+	return {
+		...res,
+		head: {
+			title: head.title,
+			lang: head.lang,
+			elements
+		}
+	};
 }
 
 // @ts-ignore

--- a/examples/demo/public/index.tsx
+++ b/examples/demo/public/index.tsx
@@ -1,5 +1,6 @@
 import { LocationProvider, Router } from 'preact-iso/router';
 import lazy, { ErrorBoundary } from 'preact-iso/lazy';
+import { toStatic } from 'hoofd/preact';
 import hydrate from 'preact-iso/hydrate';
 import Home from './pages/home.js';
 // import About from './pages/about/index.js';
@@ -16,6 +17,7 @@ const ClassFields = lazy(async () => (await sleep(1500), import('./pages/class-f
 const Files = lazy(() => import('./pages/files/index.js'));
 const Environment = lazy(async () => (await import('./pages/environment/index.js')).Environment);
 const JSONView = lazy(async () => (await import('./pages/json.js')).JSONView);
+const MetaTags = lazy(async () => (await import('./pages/meta-tags.js')).MetaTags);
 
 function showLoading() {
 	document.body.classList.add('loading');
@@ -39,6 +41,7 @@ export function App() {
 						<Files path="/files" />
 						<Environment path="/env" />
 						<JSONView path="/json" />
+						<MetaTags path="/meta-tags" />
 						<NotFound default />
 					</Router>
 				</ErrorBoundary>
@@ -53,7 +56,10 @@ if (typeof window !== 'undefined') {
 
 export async function prerender(data) {
 	const { default: render } = await import('preact-iso/prerender');
-	return await render(<App {...data} />);
+	const res = await render(<App {...data} />);
+
+	const head = toStatic();
+	return { ...res, head };
 }
 
 // @ts-ignore

--- a/examples/demo/public/pages/meta-tags.js
+++ b/examples/demo/public/pages/meta-tags.js
@@ -1,0 +1,22 @@
+import { useLang, useTitle, useTitleTemplate, useMeta, useLink } from 'hoofd/preact';
+
+// Test meta tags prerendering
+export function MetaTags() {
+	// Will set <html lang="en">
+	useLang('nl');
+
+	// Will set title to "Welcome to hoofd | 💭"
+	useTitleTemplate('%s | 💭');
+	useTitle('Welcome to hoofd');
+
+	// Credits to an amazing person
+	useMeta({ name: 'author', content: 'Jovi De Croock' });
+	useLink({ rel: 'me', href: 'https://jovidecroock.com' });
+
+	return (
+		<div>
+			<h1>Meta tag rendering</h1>
+			<p>...check document.head in devtools</p>
+		</div>
+	);
+}

--- a/packages/wmr/src/lib/prerender.js
+++ b/packages/wmr/src/lib/prerender.js
@@ -153,6 +153,7 @@ async function workerCode({ cwd, out, publicPath }) {
 			...new Set(
 				(head.metas || []).map(c => {
 					const attrs = Object.keys(c)
+						.filter(k => c[k])
 						.map(k => `${enc(k)}="${enc(c[k])}"`)
 						.join(' ');
 					return `<meta ${attrs}>`;

--- a/packages/wmr/src/plugins/optimize-graph-plugin.js
+++ b/packages/wmr/src/plugins/optimize-graph-plugin.js
@@ -9,7 +9,7 @@ import { hasDebugFlag } from '../lib/output-utils.js';
 const DEBUG = hasDebugFlag();
 
 const DEFAULT_STYLE_LOAD_FN = '$w_s$';
-const DEFAULT_STYLE_LOAD_IMPL = `function $w_s$(e,t){if(typeof document==='undefined'){wmr.ssr.head.elements.add({type:'link',props:{rel:'stylesheet',href:e}});}else{document.querySelector('link[rel=stylesheet][href="'+e+'"]')||((t=document.createElement("link")).rel="stylesheet",t.href=e,document.head.appendChild(t))}}`;
+const DEFAULT_STYLE_LOAD_IMPL = `function $w_s$(e,t){typeof document=='undefined'?wmr.ssr.head.elements.add({type:'link',props:{rel:'stylesheet',href:e}}):document.querySelector('link[rel=stylesheet][href="'+e+'"]')||((t=document.createElement("link")).rel="stylesheet",t.href=e,document.head.appendChild(t))}`;
 
 /**
  * Performs graph-based optimizations on generated assets and chunks:

--- a/packages/wmr/src/plugins/optimize-graph-plugin.js
+++ b/packages/wmr/src/plugins/optimize-graph-plugin.js
@@ -9,7 +9,7 @@ import { hasDebugFlag } from '../lib/output-utils.js';
 const DEBUG = hasDebugFlag();
 
 const DEFAULT_STYLE_LOAD_FN = '$w_s$';
-const DEFAULT_STYLE_LOAD_IMPL = `function $w_s$(e,t){if(typeof document === 'undefined') return;document.querySelector('link[rel=stylesheet][href="'+e+'"]')||((t=document.createElement("link")).rel="stylesheet",t.href=e,document.head.appendChild(t))}`;
+const DEFAULT_STYLE_LOAD_IMPL = `function $w_s$(e,t){if(typeof document==='undefined'){wmr.ssr.head.elements.add({type:'link',props:{rel:'stylesheet',href:e}});}else{document.querySelector('link[rel=stylesheet][href="'+e+'"]')||((t=document.createElement("link")).rel="stylesheet",t.href=e,document.head.appendChild(t))}}`;
 
 /**
  * Performs graph-based optimizations on generated assets and chunks:

--- a/packages/wmr/src/plugins/optimize-graph-plugin.js
+++ b/packages/wmr/src/plugins/optimize-graph-plugin.js
@@ -9,7 +9,7 @@ import { hasDebugFlag } from '../lib/output-utils.js';
 const DEBUG = hasDebugFlag();
 
 const DEFAULT_STYLE_LOAD_FN = '$w_s$';
-const DEFAULT_STYLE_LOAD_IMPL = `function $w_s$(e,t){document.querySelector('link[rel=stylesheet][href="'+e+'"]')||((t=document.createElement("link")).rel="stylesheet",t.href=e,document.head.appendChild(t))}`;
+const DEFAULT_STYLE_LOAD_IMPL = `function $w_s$(e,t){if(typeof document === 'undefined') return;document.querySelector('link[rel=stylesheet][href="'+e+'"]')||((t=document.createElement("link")).rel="stylesheet",t.href=e,document.head.appendChild(t))}`;
 
 /**
  * Performs graph-based optimizations on generated assets and chunks:

--- a/packages/wmr/src/plugins/wmr/client-prod.js
+++ b/packages/wmr/src/plugins/wmr/client-prod.js
@@ -1,6 +1,8 @@
 export function createHotContext() {}
 
 export function style(filename) {
+	if (typeof document === 'undefined') return;
+
 	const prev = document.querySelector('link[rel=stylesheet][href="' + filename + '"]');
 	if (prev) return;
 	const node = document.createElement('link');

--- a/packages/wmr/src/plugins/wmr/client-prod.js
+++ b/packages/wmr/src/plugins/wmr/client-prod.js
@@ -1,12 +1,15 @@
 export function createHotContext() {}
 
 export function style(filename) {
-	if (typeof document === 'undefined') return;
-
-	const prev = document.querySelector('link[rel=stylesheet][href="' + filename + '"]');
-	if (prev) return;
-	const node = document.createElement('link');
-	node.rel = 'stylesheet';
-	node.href = filename;
-	document.head.appendChild(node);
+	if (typeof document === 'undefined') {
+		// eslint-disable-next-line no-undef
+		wmr.ssr.head.elements.add({ type: 'link', props: { rel: 'stylesheet', href: filename } });
+	} else {
+		const prev = document.querySelector('link[rel=stylesheet][href="' + filename + '"]');
+		if (prev) return;
+		const node = document.createElement('link');
+		node.rel = 'stylesheet';
+		node.href = filename;
+		document.head.appendChild(node);
+	}
 }

--- a/packages/wmr/test/fixtures/prerender-external/index.js
+++ b/packages/wmr/test/fixtures/prerender-external/index.js
@@ -1,4 +1,3 @@
 export function prerender() {
-	document.title = `Page: ${location.pathname}`;
-	return { html: '<h1>it works</h1>', links: ['/'] };
+	return { html: '<h1>it works</h1>', links: ['/'], head: { title: `Page: ${location.pathname}` } };
 }

--- a/packages/wmr/test/fixtures/prod-head/index.js
+++ b/packages/wmr/test/fixtures/prod-head/index.js
@@ -1,15 +1,15 @@
 const PAGES = ['/', '/other.html'];
 
 export function prerender() {
-	const link = document.createElement('link');
-	link.rel = 'icon';
-	link.href = `data:,favicon-for-${location.pathname}`;
-	document.head.appendChild(link);
-
-	document.head.insertAdjacentHTML('beforeend', '<meta property="og:title" content="Become an SEO Expert">');
-
-	document.title = `Page: ${location.pathname}`;
-
 	const html = `<h1>page = ${location.pathname}</h1>`;
-	return { html, links: PAGES };
+	return {
+		html,
+		links: PAGES,
+		head: {
+			lang: 'de',
+			links: [{ rel: 'icon', href: `data:,favicon-for-${location.pathname}` }],
+			metas: [{ property: 'og:title', content: 'Become an SEO Expert' }],
+			title: `Page: ${location.pathname}`
+		}
+	};
 }

--- a/packages/wmr/test/fixtures/prod-head/index.js
+++ b/packages/wmr/test/fixtures/prod-head/index.js
@@ -7,8 +7,10 @@ export function prerender() {
 		links: PAGES,
 		head: {
 			lang: 'de',
-			links: [{ rel: 'icon', href: `data:,favicon-for-${location.pathname}` }],
-			metas: [{ property: 'og:title', content: 'Become an SEO Expert' }],
+			elements: [
+				{ type: 'link', props: { rel: 'icon', href: `data:,favicon-for-${location.pathname}` } },
+				{ type: 'meta', props: { property: 'og:title', content: 'Become an SEO Expert' } }
+			],
 			title: `Page: ${location.pathname}`
 		}
 	};

--- a/packages/wmr/test/fixtures/prod-prerender-json/index.js
+++ b/packages/wmr/test/fixtures/prod-prerender-json/index.js
@@ -1,11 +1,9 @@
 import foo from './foo.json';
 
 export function prerender() {
-	document.title = `Page: ${location.pathname}`;
-
 	const html = `<div>
 		<h1>page = ${location.pathname}</h1>
 		<p>JSON: ${JSON.stringify(foo)}</p>
 	</div>`;
-	return { html, links: ['/'] };
+	return { html, links: ['/'], head: { title: `Page: ${location.pathname}` } };
 }

--- a/packages/wmr/test/production.test.js
+++ b/packages/wmr/test/production.test.js
@@ -441,15 +441,15 @@ describe('production', () => {
 
 			const index = await fs.readFile(path.join(env.tmp.path, 'dist', 'index.html'), 'utf8');
 			expect(index).toMatch('<title>Page: /</title>');
-			expect(index).toMatch('<link rel="icon" href="data:,favicon-for-/">');
+			expect(index).toMatch('<link href="data:,favicon-for-/" rel="icon">');
 			expect(index).toMatch('<h1>page = /</h1>');
-			expect(index).toMatch(`<meta property="og:title" content="Become an SEO Expert">`);
+			expect(index).toMatch(`<meta content="Become an SEO Expert" property="og:title">`);
 
 			const other = await fs.readFile(path.join(env.tmp.path, 'dist', 'other.html'), 'utf8');
 			expect(other).toMatch('<title>Page: /other.html</title>');
-			expect(other).toMatch('<link rel="icon" href="data:,favicon-for-/other.html">');
+			expect(other).toMatch('<link href="data:,favicon-for-/other.html" rel="icon">');
 			expect(other).toMatch('<h1>page = /other.html</h1>');
-			expect(other).toMatch(`<meta property="og:title" content="Become an SEO Expert">`);
+			expect(other).toMatch(`<meta content="Become an SEO Expert" property="og:title">`);
 		});
 
 		it('should support prerendering json', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4204,6 +4204,11 @@ homedir-polyfill@^1.0.0:
   dependencies:
     parse-passwd "^1.0.0"
 
+hoofd@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/hoofd/-/hoofd-1.2.2.tgz#67ebded9edf45337c293bad40ba0aec543d560c6"
+  integrity sha512-kkJDsAWF5PQFXjCgqqkr6qNm8oFsC59piTcvciWrMBTojT+WEXAMKfa/iOTGY3oLP1Vidkp2mkJKnFFhv2HNSw==
+
 hosted-git-info@^2.1.4:
   version "2.8.8"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.8.tgz#7539bd4bc1e0e0a895815a2e0262420b12858488"


### PR DESCRIPTION
Prerendering of meta tags and other elements in the documents head previously worked by relying on a custom implementation of the global `document` object. We only did add a tiny subset of the methods that are available in the browser, but doing so breaks nearly all server detection code in third party libs. Checked various libraries and the most common snippet to do that is a variation of:

```js
// This was always false in wmr because we supply a fake document global
const isServer = typeof document === "undefined";
```

Because we did patch in a global document object, this value is always `false`, even during SSR.

Another problem with that approach in genral is that we'll always have a biased subset of the API that may work with our code, but is not guaranteed to work with third-party libraries. Examples of those are our very own [hoofd](https://github.com/JoviDeCroock/hoofd) and [react-helmet](https://github.com/nfl/react-helmet).

This is more complicated by the fact that to check if a meta tag is already set libraries use the `document.querySelector` API. And I feel like providing that bloats up WMR unnecessarily and only leads us down the rabbit hole of adding more and more DOM APIs.

Instead a much more reliable approach is to ditch the whole idea of supplying a fake document in the first place and instead rely on consumers supplying the head value.

TODO:

- [x] Update `document` usage in `docs` site
- [x] Check prerendering of `style()` (should be fine, but just to be sure)