### PR TITLE
refactor: Clear output directory without deleting it

### DIFF
--- a/.changeset/light-ravens-design.md
+++ b/.changeset/light-ravens-design.md
@@ -1,0 +1,5 @@
+---
+'wmr': patch
+---
+
+Instead of deleting the build output folder, it is instead emptied, allowing references to it to remain intact.

--- a/packages/wmr/src/build.js
+++ b/packages/wmr/src/build.js
@@ -18,7 +18,13 @@ export default async function build(options = {}) {
 
 	options = await normalizeOptions(options, 'build');
 
-	await fs.rmdir(options.out, { recursive: true });
+	// Clears out the output folder without deleting it -- useful
+	// when mounted with Docker and the like
+	(await fs.readdir(options.out)).forEach(async item => {
+		item = path.join(options.out, item);
+		if ((await fs.stat(item)).isFile()) await fs.unlink(item);
+		else await fs.rmdir(item, { recursive: true });
+	});
 
 	const bundleOutput = await bundleProd(options);
 


### PR DESCRIPTION
Stumbled across an issue over on the Vite repo asking for the output directory to be emptied without deleting the directory itself. This came from a user who had an containerized environment and the build output directory was a mount point. Simply deleting the directory caused issues in their setup.

https://github.com/vitejs/vite/issues/709

That's something our users could potentially run into as well, so I thought it made a fitting change. Not quite as nice, as it'll need to scan for each of the top-level items and clear them out, slightly slower too, but so long as the directory doesn't have a ton of top-level items it shouldn't be noticeable. 