### PR TITLE
Add filesystem helpers

### DIFF
--- a/packages/wmr/src/lib/fs-utils.js
+++ b/packages/wmr/src/lib/fs-utils.js
@@ -1,0 +1,29 @@
+import { promises as fs } from 'fs';
+
+/**
+ * Implementation of fs.rm() for Node 12+
+ * See: https://nodejs.org/api/fs.html#fs_fspromises_rm_path_options
+ * @param {string | Buffer | URL} path
+ * @param {{ force?: boolean, maxRetries?: number, recursive?: boolean, retryDelay?: number }} [options]
+ */
+export async function rm(path, options) {
+	if (fs.rm) return fs.rm(path, options);
+	options = options || {};
+	const stats = await fs.stat(path);
+	if (stats.isDirectory()) return fs.rmdir(path, options);
+	return fs.unlink(path);
+}
+
+export function isDirectory(path) {
+	return fs
+		.stat(path)
+		.then(s => s.isDirectory())
+		.catch(() => false);
+}
+
+export function isFile(path) {
+	return fs
+		.stat(path)
+		.then(s => s.isFile())
+		.catch(() => false);
+}

--- a/packages/wmr/src/lib/normalize-options.js
+++ b/packages/wmr/src/lib/normalize-options.js
@@ -1,6 +1,7 @@
 import { resolve, join } from 'path';
 import { promises as fs } from 'fs';
 import url from 'url';
+import { isFile, isDirectory } from './fs-utils.js';
 import { readEnvFiles } from './environment.js';
 import { compileSingleModule } from './compile-single-module.js';
 import { debug, setDebugCliArg } from './output-utils.js';
@@ -220,18 +221,4 @@ function mergeConfig(a, b) {
 	}
 
 	return merged;
-}
-
-function isDirectory(path) {
-	return fs
-		.stat(path)
-		.then(s => s.isDirectory())
-		.catch(() => false);
-}
-
-function isFile(path) {
-	return fs
-		.stat(path)
-		.then(s => s.isFile())
-		.catch(() => false);
 }


### PR DESCRIPTION
@rschristian's #578 gave me an idea: we have a few cases where soon we'll be able to move to some of the lovely Node 14+ `fs.*()` methods like `fs.rm(p,{recursive:true})`, but for now we need to support Node 12. Adding a little "fs helpers" lib will make this super easy to change in the future, and lets us use the methods now.