### PR TITLE
Fix ERR_FS_EISDIR error on rebuilds

### DIFF
--- a/packages/wmr/src/build.js
+++ b/packages/wmr/src/build.js
@@ -21,7 +21,7 @@ export default async function build(options) {
 
 	// Clears out the output folder without deleting it -- useful
 	// when mounted with Docker and the like
-	await Promise.all((await fs.readdir(options.out)).map(item => rm(path.join(options.out, item))));
+	await Promise.all((await fs.readdir(options.out)).map(item => rm(path.join(options.out, item), { recursive: true })));
 
 	const bundleOutput = await bundleProd(options);
 


### PR DESCRIPTION
Fix a regression introduced in #580.

Node's `fs.rm()` function only deletes directories when `recursive: true` is set. This error occured in a few past CI runs since merging #580 and I can reproduce it locally when running our test suite.

Proof: https://github.com/nodejs/node/blob/18e4f405b14b26f971d5f108b92224e7c1fe34c9/lib/internal/fs/utils.js#L746