### PR TITLE
Use Route components in template for potential TS users

### DIFF
--- a/.changeset/fast-lions-explain.md
+++ b/.changeset/fast-lions-explain.md
@@ -1,0 +1,5 @@
+---
+'create-wmr': patch
+---
+
+Use Route components in create template to make it easier for potential TypeScript users

--- a/packages/create-wmr/tpl/public/index.js
+++ b/packages/create-wmr/tpl/public/index.js
@@ -1,5 +1,5 @@
 import hydrate from 'preact-iso/hydrate';
-import { LocationProvider, Router } from 'preact-iso/router';
+import { LocationProvider, Router, Route } from 'preact-iso/router';
 import lazy, { ErrorBoundary } from 'preact-iso/lazy';
 import Home from './pages/home/index.js';
 import NotFound from './pages/_404.js';
@@ -14,9 +14,9 @@ export function App() {
 				<Header />
 				<ErrorBoundary>
 					<Router>
-						<Home path="/" />
-						<About path="/about" />
-						<NotFound default />
+						<Route path="/" component={Home} />
+						<Route path="/about" component={About} />
+						<Route default component={NotFound} />
 					</Router>
 				</ErrorBoundary>
 			</div>


### PR DESCRIPTION
Although our current template is JS-only, I'd expect a good portion (if not most) of our users to opt into TypeScript. We do leverage some trickery to make a global `path` prop work, but it's more consisten with other components to opt for  `Route` instead.

In most user's mind a JSX element is equivalent to a function call and in that model it's strange to see additional props besides ref/key.