### PR TITLE
Support returning prerender data

### DIFF
--- a/.changeset/long-moons-think.md
+++ b/.changeset/long-moons-think.md
@@ -1,0 +1,5 @@
+---
+'wmr': minor
+---
+
+Support injecting prerender data by returning a `data` key from the prerender function

--- a/examples/demo/public/index.tsx
+++ b/examples/demo/public/index.tsx
@@ -67,6 +67,9 @@ export async function prerender(data) {
 
 	return {
 		...res,
+		data: {
+			hello: 'world',
+		},
 		head: {
 			title: head.title,
 			lang: head.lang,

--- a/packages/preact-iso/prerender.js
+++ b/packages/preact-iso/prerender.js
@@ -46,8 +46,7 @@ export default async function prerender(vnode, options) {
 	};
 
 	try {
-		let html = await render();
-		html += `<script type="isodata"></script>`;
+		const html = await render();
 		return { html, links };
 	} finally {
 		vnodeHook = null;

--- a/packages/wmr/src/lib/prerender.js
+++ b/packages/wmr/src/lib/prerender.js
@@ -172,6 +172,12 @@ async function workerCode({ cwd, out, publicPath }) {
 			if (result.head) {
 				head = result.head;
 			}
+
+			if (result.data && typeof result.data === 'object') {
+				body += `<script type="isodata">${JSON.stringify(result.data)}</script>`;
+			} else if (result.data) {
+				console.warn('You passed in prerender-data in a non-object format: ', result.data);
+			}
 		} else {
 			body = result;
 		}

--- a/packages/wmr/test/fixtures/prerender-data/index.html
+++ b/packages/wmr/test/fixtures/prerender-data/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf8" />
+		<title>default title</title>
+	</head>
+	<body>
+		<script src="https://example.com/foo.js" type="module"></script>
+		<script src="./index.js" type="module"></script>
+	</body>
+</html>

--- a/packages/wmr/test/fixtures/prerender-data/index.html
+++ b/packages/wmr/test/fixtures/prerender-data/index.html
@@ -5,7 +5,6 @@
 		<title>default title</title>
 	</head>
 	<body>
-		<script src="https://example.com/foo.js" type="module"></script>
 		<script src="./index.js" type="module"></script>
 	</body>
 </html>

--- a/packages/wmr/test/fixtures/prerender-data/index.js
+++ b/packages/wmr/test/fixtures/prerender-data/index.js
@@ -1,0 +1,3 @@
+export function prerender() {
+	return { html: '<h1>it works</h1>', links: ['/'], data: { hello: 'world' } };
+}

--- a/packages/wmr/test/production.test.js
+++ b/packages/wmr/test/production.test.js
@@ -444,6 +444,17 @@ describe('production', () => {
 			expect(index).toMatch('it works');
 		});
 
+		it('should inject prerendered data into the html', async () => {
+			await loadFixture('prerender-data', env);
+			instance = await runWmr(env.tmp.path, 'build', '--prerender');
+			const code = await instance.done;
+			expect(instance.output.join('\n')).toMatch(/Prerendered 1 page/i);
+			expect(code).toBe(0);
+
+			const index = await fs.readFile(path.join(env.tmp.path, 'dist', 'index.html'), 'utf8');
+			expect(index).toMatch('<script type="isodata">{"hello":"world"}</script>');
+		});
+
 		it('should support prerendered HTML, title & meta tags', async () => {
 			await loadFixture('prod-head', env);
 			instance = await runWmr(env.tmp.path, 'build', '--prerender');


### PR DESCRIPTION
This add support for returning a `data` key from the prerender, this enables us to for instance use [prepass](https://github.com/preactjs/preact-ssr-prepass) or a manual `fetch` call to get some data needed for rendering.