### PR TITLE
(preact-iso): register link click handler immediately to prevent race condition

### DIFF
--- a/.changeset/calm-olives-allow.md
+++ b/.changeset/calm-olives-allow.md
@@ -1,0 +1,5 @@
+---
+"preact-iso": patch
+---
+
+Fixes a race condition in preact-iso `Router` by registering the link click handler immediately.

--- a/packages/preact-iso/router.js
+++ b/packages/preact-iso/router.js
@@ -63,7 +63,7 @@ export function LocationProvider(props) {
 		return { url, path, query: Object.fromEntries(u.searchParams), route, wasPush };
 	}, [url]);
 
-	useEffect(() => {
+	useLayoutEffect(() => {
 		addEventListener('click', route);
 		addEventListener('popstate', route);
 

--- a/packages/preact-iso/test/router.test.js
+++ b/packages/preact-iso/test/router.test.js
@@ -429,7 +429,7 @@ describe('Router', () => {
 		await sleep(20);
 
 		scratch.querySelector('a[href="/foo#foo"]').click();
-		await sleep(100);
+		await sleep(20);
 		expect(Route).toHaveBeenCalledTimes(1);
 		expect(loc).toMatchObject({ url: '/foo#foo', path: '/foo' });
 		expect(pushState).toHaveBeenCalled();


### PR DESCRIPTION
This was using `useEffect()` to register the handler, but that waits 1 rAF. During the frame delay, clicks are ignored by the router.