### PR TITLE
Fix directory plugin not resolving in prod builds

### DIFF
--- a/.changeset/good-beans-add.md
+++ b/.changeset/good-beans-add.md
@@ -1,0 +1,5 @@
+---
+"@wmrjs/directory-import": patch
+---
+
+Fix directory plugin not resolving in prod builds

--- a/packages/directory-plugin/src/index.js
+++ b/packages/directory-plugin/src/index.js
@@ -14,11 +14,11 @@ function directoryPlugin(options) {
 		async resolveId(id, importer) {
 			if (!id.startsWith('dir:')) return;
 
-			const resolved = await this.resolve(id.slice(4) + '\0', importer, { skipSelf: true });
+			const resolved = path.resolve(options.cwd || '.', importer, id.slice(4));
+			const stats = await fs.stat(resolved);
+			if (!stats.isDirectory()) throw Error(`Not a directory.`);
 
-			if (resolved) {
-				return '\0dir:' + pathToPosix(resolved.id).replace(/\0$/, '');
-			}
+			return '\0dir:' + resolved;
 		},
 		async load(id) {
 			if (!id.startsWith('\0dir:')) return;

--- a/packages/directory-plugin/src/index.js
+++ b/packages/directory-plugin/src/index.js
@@ -1,37 +1,42 @@
 import { promises as fs } from 'fs';
 import path from 'path';
 
-const pathToPosix = p => p.split(path.sep).join(path.posix.sep);
-
 /**
- * @param {object} [options]
- * @param {string} [options.cwd]
+ * @param {import("wmr").Options} options
+ * @param {string} options.cwd
  * @returns {import('rollup').Plugin}
  */
 function directoryPlugin(options) {
+	const PREFIX = 'dir:';
+	const INTERNAL = '\0dir:';
+
 	options.plugins.push({
 		name: 'directory',
 		async resolveId(id, importer) {
-			if (!id.startsWith('dir:')) return;
+			if (!id.startsWith(PREFIX)) return;
 
-			const resolved = path.resolve(options.cwd || '.', importer, id.slice(4));
-			const stats = await fs.stat(resolved);
-			if (!stats.isDirectory()) throw Error(`Not a directory.`);
-
-			return '\0dir:' + resolved;
+			id = id.slice(PREFIX.length);
+			const resolved = await this.resolve(id, importer, { skipSelf: true });
+			return INTERNAL + (resolved ? resolved.id : id);
 		},
 		async load(id) {
-			if (!id.startsWith('\0dir:')) return;
+			if (!id.startsWith(INTERNAL)) return;
 
 			// remove the "\dir:" prefix and convert to an absolute path:
-			id = path.resolve(options.cwd || '.', id.slice(5));
+			id = id.slice(INTERNAL.length);
+			let dir = id.split(path.posix.sep).join(path.sep);
+			if (!path.isAbsolute(dir)) {
+				dir = path.join(options.cwd, dir);
+			}
+
+			const stats = await fs.stat(dir);
+			if (!stats.isDirectory()) throw Error(`Not a directory.`);
 
 			// watch the directory for changes:
-			this.addWatchFile(id);
+			this.addWatchFile(dir);
 
 			// generate a module that exports the directory contents as an Array:
-			const files = (await fs.readdir(id)).filter(d => d[0] != '.');
-
+			const files = (await fs.readdir(dir)).filter(d => d[0] != '.');
 			return `export default ${JSON.stringify(files)}`;
 		}
 	});

--- a/packages/wmr/test/fixtures/directory-import/public/foo/a.js
+++ b/packages/wmr/test/fixtures/directory-import/public/foo/a.js
@@ -1,0 +1,1 @@
+export const a = 'a';

--- a/packages/wmr/test/fixtures/directory-import/public/foo/b.js
+++ b/packages/wmr/test/fixtures/directory-import/public/foo/b.js
@@ -1,0 +1,1 @@
+export const b = 'b';

--- a/packages/wmr/test/fixtures/directory-import/public/foo/c.js
+++ b/packages/wmr/test/fixtures/directory-import/public/foo/c.js
@@ -1,0 +1,1 @@
+export const c = 'c';

--- a/packages/wmr/test/fixtures/directory-import/public/index.html
+++ b/packages/wmr/test/fixtures/directory-import/public/index.html
@@ -1,0 +1,2 @@
+<ul></ul>
+<script type="module" src="./index.js"></script>

--- a/packages/wmr/test/fixtures/directory-import/public/index.js
+++ b/packages/wmr/test/fixtures/directory-import/public/index.js
@@ -1,0 +1,9 @@
+import files from 'dir:./foo';
+
+const list = document.querySelector('ul');
+
+files.forEach(file => {
+	const el = document.createElement('li');
+	el.textContent = file;
+	list.appendChild(el);
+});

--- a/packages/wmr/test/fixtures/directory-import/public/invalid.js
+++ b/packages/wmr/test/fixtures/directory-import/public/invalid.js
@@ -1,0 +1,3 @@
+import files from 'dir:./foo/a.js';
+
+console.log(files);

--- a/packages/wmr/test/fixtures/directory-import/wmr.config.mjs
+++ b/packages/wmr/test/fixtures/directory-import/wmr.config.mjs
@@ -1,0 +1,5 @@
+import directoryPlugin from '@wmrjs/directory-import';
+
+export default function (config) {
+	directoryPlugin(config);
+}

--- a/packages/wmr/test/plugins/directory-plugin.test.js
+++ b/packages/wmr/test/plugins/directory-plugin.test.js
@@ -1,0 +1,91 @@
+import path from 'path';
+import {
+	setupTest,
+	teardown,
+	loadFixture,
+	runWmrFast,
+	getOutput,
+	runWmr,
+	serveStatic,
+	withLog
+} from '../test-helpers.js';
+
+jest.setTimeout(30000);
+
+describe('directory-plugin', () => {
+	/** @type {TestEnv} */
+	let env;
+	/** @type {WmrInstance} */
+	let instance;
+	/** @type {(()=>void)[]} */
+	let cleanup = [];
+
+	beforeEach(async () => {
+		env = await setupTest();
+	});
+
+	afterEach(async () => {
+		await teardown(env);
+		instance.close();
+		await Promise.all(cleanup.map(c => Promise.resolve().then(c)));
+		cleanup.length = 0;
+	});
+
+	describe('development', () => {
+		it('should import directories', async () => {
+			await loadFixture('directory-import', env);
+			instance = await runWmrFast(env.tmp.path);
+			const output = await getOutput(env, instance);
+			expect(output).toMatch(/a\.js.*b\.js.*c\.js/);
+		});
+
+		it('should throw when the target is not a directory', async () => {
+			await loadFixture('directory-import', env);
+			instance = await runWmrFast(env.tmp.path);
+			await getOutput(env, instance);
+
+			const res = await env.page.evaluate(`import('./invalid.js').then(() => true).catch(() => false)`);
+			expect(res).toEqual(false);
+		});
+	});
+
+	describe('production', () => {
+		it('should import directories', async () => {
+			await loadFixture('directory-import', env);
+			instance = await runWmr(env.tmp.path, 'build');
+			await withLog(instance.output, async () => {
+				const code = await instance.done;
+				expect(code).toEqual(0);
+
+				const { address, stop } = serveStatic(path.join(env.tmp.path, 'dist'));
+				cleanup.push(stop);
+
+				await env.page.goto(address, {
+					waitUntil: ['networkidle0', 'load']
+				});
+
+				const text = await env.page.content();
+				expect(text).toMatch(/a\.js.*b\.js.*c\.js/);
+			});
+		});
+
+		it('should throw when the target is not a directory', async () => {
+			await loadFixture('directory-import', env);
+			instance = await runWmr(env.tmp.path, 'build');
+			await withLog(instance.output, async () => {
+				const code = await instance.done;
+				expect(code).toEqual(0);
+
+				const { address, stop } = serveStatic(path.join(env.tmp.path, 'dist'));
+				cleanup.push(stop);
+
+				await env.page.goto(address, {
+					waitUntil: ['networkidle0', 'load']
+				});
+
+				const res = await env.page.evaluate(`import('./invalid.js').then(() => true).catch(() => false)`);
+				expect(res).toEqual(false);
+			});
+		});
+	});
+});

--- a/packages/wmr/test/test-helpers.js
+++ b/packages/wmr/test/test-helpers.js
@@ -53,6 +53,7 @@ export async function loadFixture(name, env) {
 	await ncp(fixture, env.tmp.path);
 	try {
 		await fs.mkdir(path.join(env.tmp.path, 'node_modules', 'wmr'), { recursive: true });
+		await fs.mkdir(path.join(env.tmp.path, 'node_modules', '@wmrjs', 'directory-import', 'src'), { recursive: true });
 	} catch (err) {
 		if (!/EEXIST/.test(err.message)) {
 			throw err;
@@ -64,6 +65,15 @@ export async function loadFixture(name, env) {
 	await fs.copyFile(
 		path.join(__dirname, '..', 'package.json'),
 		path.join(env.tmp.path, 'node_modules', 'wmr', 'package.json')
+	);
+
+	await fs.copyFile(
+		path.join(__dirname, '..', '..', 'directory-plugin', 'src', 'index.js'),
+		path.join(env.tmp.path, 'node_modules', '@wmrjs', 'directory-import', 'src', 'index.js')
+	);
+	await fs.copyFile(
+		path.join(__dirname, '..', '..', 'directory-plugin', 'package.json'),
+		path.join(env.tmp.path, 'node_modules', '@wmrjs', 'directory-import', 'package.json')
 	);
 }
 


### PR DESCRIPTION
Rollup's `PluginContext.resolve()` does not resolve directories, whereas our dev-time version does (because it doesn't/can't check for existence). Using `path.resolve()` fixes this.

**Note: I have not yet tested that this PR works!**