### PR TITLE
Fix unable to start starter template

### DIFF
--- a/.changeset/long-seas-tan.md
+++ b/.changeset/long-seas-tan.md
@@ -1,0 +1,5 @@
+---
+'create-wmr': patch
+---
+
+Fix unable to load default template file

--- a/packages/create-wmr/tpl/wmr.config.mjs
+++ b/packages/create-wmr/tpl/wmr.config.mjs
@@ -1,5 +1,5 @@
 import { defineConfig } from 'wmr';
 
-module.exports = defineConfig({
+export default defineConfig({
 	/* Your configuration here */
 });


### PR DESCRIPTION
This was caused by mixed module syntaxes.