### PR TITLE
(wmr): Fix cli flags

### DIFF
--- a/.changeset/silver-needles-grin.md
+++ b/.changeset/silver-needles-grin.md
@@ -1,0 +1,5 @@
+---
+'wmr': patch
+---
+
+Fixes some of WMR's CLI flags labelled as global when they're not

--- a/packages/wmr/src/cli.js
+++ b/packages/wmr/src/cli.js
@@ -15,8 +15,6 @@ function bool(v) {
 
 // global options
 prog
-	.option('--public', 'Your web app root directory (default: ./public)')
-	.option('--out', 'Where to store generated files (default: ./dist)')
 	.option('--cwd', 'The working directory - equivalent to "(cd FOO && wmr)"')
 	// Setting env variables isn't common knowledege for many windows users. Much
 	// easier to pass a flag to our binary instead.
@@ -24,6 +22,8 @@ prog
 
 prog
 	.command('build', 'make a production build')
+	.option('--public', 'Your web app root directory (default: ./public)')
+	.option('--out', 'Where to store generated files (default: ./dist)')
 	.option('--prerender', 'Pre-render the application to HTML')
 	.option('--sourcemap', 'Enable Source Maps')
 	.option('--visualize', 'Launch interactive bundle visualizer')
@@ -46,6 +46,7 @@ prog
 
 prog
 	.command('start', 'Start a development server', { default: true })
+	.option('--public', 'Your web app root directory (default: ./public)')
 	.option('--port, -p', 'HTTP port to listen on (default: $PORT or 8080)')
 	.option('--host', 'HTTP host to listen on (default: localhost)')
 	.option('--http2', 'Use HTTP/2 (default: false)')


### PR DESCRIPTION
Few issues this solves:
  * `yarn wmr serve --help` printed out two competing descriptions for the `--out` flag (1 global, 1 local)
  * `--public` isn't relevant for `serve`'s functionality
  *  `--out` for the dev server seems kind of odd and not intended? Basically `.cache/` will contain only the node modules (`@npm/`) while all the app stuff gets moved into whatever the `--out` dir is set to. Spreads the contents of `.cache/` over two directories which seems like an odd thing to want.