### PR TITLE
Upgrade to Terser 5.7.0

### DIFF
--- a/.changeset/early-masks-mix.md
+++ b/.changeset/early-masks-mix.md
@@ -1,0 +1,5 @@
+---
+"wmr": patch
+---
+
+Upgrade to Terser 5

--- a/packages/wmr/package.json
+++ b/packages/wmr/package.json
@@ -149,7 +149,7 @@
 		"stylis": "^4.0.10",
 		"sucrase": "^3.17.0",
 		"tar-stream": "^2.1.3",
-		"terser": "^4.8.0",
+		"terser": "^5.7.0",
 		"tmp-promise": "^3.0.2",
 		"totalist": "^1.1.0",
 		"utf-8-validate": "^5.0.2",

--- a/packages/wmr/rollup.config.js
+++ b/packages/wmr/rollup.config.js
@@ -9,7 +9,7 @@ import nodeResolve from '@rollup/plugin-node-resolve';
 import alias from '@rollup/plugin-alias';
 import json from '@rollup/plugin-json';
 import builtins from 'builtin-modules';
-import terser from 'terser';
+import { minify } from 'terser';
 
 /** @type {import('rollup').RollupOptions} */
 const config = {
@@ -27,8 +27,8 @@ const config = {
 		plugins: [
 			{
 				name: 'minify',
-				renderChunk(code) {
-					const result = terser.minify(code, {
+				async renderChunk(code) {
+					const result = await minify(code, {
 						ecma: 2019,
 						module: true,
 						compress: {
@@ -44,7 +44,8 @@ const config = {
 							ecma: 2019
 						}
 					});
-					return result.code || null;
+					if (typeof result.code === 'string') code = result.code;
+					return { code };
 				}
 			}
 		]

--- a/packages/wmr/src/lib/npm-middleware-cache.js
+++ b/packages/wmr/src/lib/npm-middleware-cache.js
@@ -1,6 +1,6 @@
 import { promises as fs } from 'fs';
 import zlib from 'zlib';
-import terser from 'terser';
+import { minify } from 'terser';
 import { dirname, resolve } from 'path';
 
 // TODO: this could be indefinite, since cache keys are deterministic (version+path)
@@ -34,43 +34,44 @@ export const BROTLI_OPTS = {
  * @TODO move this into a Worker
  */
 function upgradeToBrotli(mem) {
-	return new Promise((resolve, reject) => {
-		// console.log(`Upgrading ${mem.module}/${mem.path} to compressed version...`);
-		// const start = Date.now();
-		mem.upgrading = true;
-		const result = terser.minify(mem.code, {
-			mangle: {
-				// Temporary workaround for duplicate identifier bug in Terser 4/5:
-				// https://github.com/terser/terser/issues/800#issuecomment-701017137
-				keep_fnames: true
-			},
-			compress: true,
-			module: true,
-			ecma: 9,
-			safari10: true,
-			sourceMap: false
+	// console.log(`Upgrading ${mem.module}/${mem.path} to compressed version...`);
+	// const start = Date.now();
+	mem.upgrading = true;
+	let error;
+	return minify(mem.code, {
+		mangle: {
+			// Temporary workaround for duplicate identifier bug in Terser 4/5:
+			// https://github.com/terser/terser/issues/800#issuecomment-701017137
+			keep_fnames: true
+		},
+		compress: true,
+		module: true,
+		ecma: 2018,
+		safari10: true,
+		sourceMap: false
+	})
+		.catch(err => {
+			console.error(err);
+			error = err;
+			return { code: undefined };
+		})
+		.then(result => {
+			mem.code = result.code || mem.code;
+			const cacheFile = getCachePath(mem, mem.cwd);
+			fs.writeFile(cacheFile, mem.code);
+			return new Promise((resolve, reject) => {
+				zlib.brotliCompress(mem.code, BROTLI_OPTS, (err, data) => {
+					mem.upgrading = false;
+					if (err && error) {
+						return reject(Error(`Minification and Brotli compression failed for ${mem.module}/${mem.path}.`));
+					}
+					mem.brotli = data;
+					fs.writeFile(cacheFile + '.br', data);
+					// console.log(`  > ${mem.module}/${mem.path} upgraded in ${Date.now() - start}ms`);
+					resolve(null);
+				});
+			});
 		});
-		if (result.warnings) {
-			console.warn(result.warnings.join('\n'));
-		}
-		if (result.error) {
-			console.error(result.error);
-		} else {
-			mem.code = result.code;
-		}
-		const cacheFile = getCachePath(mem, mem.cwd);
-		fs.writeFile(cacheFile, result.code);
-		zlib.brotliCompress(mem.code, BROTLI_OPTS, (err, data) => {
-			mem.upgrading = false;
-			if (err && result.error) {
-				return reject(Error(`Minification and Brotli compression failed for ${mem.module}/${mem.path}.`));
-			}
-			mem.brotli = data;
-			fs.writeFile(cacheFile + '.br', data);
-			// console.log(`  > ${mem.module}/${mem.path} upgraded in ${Date.now() - start}ms`);
-			resolve();
-		});
-	});
 }
 
 const compressionQueue = new Set();

--- a/packages/wmr/src/plugins/fast-minify.js
+++ b/packages/wmr/src/plugins/fast-minify.js
@@ -1,30 +1,41 @@
-import terser from 'terser';
+import { minify } from 'terser';
 import { hasDebugFlag } from '../lib/output-utils.js';
 
 /** @returns {import('rollup').Plugin} */
 export default function fastMinifyPlugin({ sourcemap = false, warnThreshold = 50, compress = false } = {}) {
 	return {
 		name: 'fast-minify',
-		renderChunk(code, chunk) {
-			const start = Date.now();
-			const out = terser.minify(code, {
-				sourceMap: sourcemap,
-				mangle: true,
-				compress,
-				module: true,
-				ecma: 9,
-				safari10: true,
-				output: {
-					comments: false
-				}
-			});
+		async renderChunk(code, chunk) {
+			let out, duration;
+			try {
+				// We only time the synhronous region here, because Terser is actually synchronous.
+				// (measuring `await` would return the cumulative time taken by all minify() calls).
+				const start = Date.now();
+				const p = minify(code, {
+					sourceMap: sourcemap,
+					mangle: true,
+					compress,
+					module: true,
+					ecma: 2018,
+					safari10: true,
+					parse: {
+						bare_returns: false,
+						html5_comments: false,
+						shebang: false
+					},
+					output: {
+						comments: false
+					}
+				});
+				duration = Date.now() - start;
+				out = await p;
+			} catch (err) {
+				return this.error(err);
+			}
 
 			// TODO: Check if tersers typings are wrong
-			if (!out.code) out.code = '';
+			if (!out.code) out.code = code;
 
-			const duration = Date.now() - start;
-			if (out.error) this.error(out.error);
-			if (out.warnings) for (const warn of out.warnings) this.warn(warn);
 			if (duration > warnThreshold && hasDebugFlag()) {
 				this.warn(`minify(${chunk.fileName}) took ${duration}ms`);
 			}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8174,7 +8174,7 @@ source-map-resolve@^0.5.0:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
-source-map-support@^0.5.6, source-map-support@~0.5.12:
+source-map-support@^0.5.6, source-map-support@~0.5.19:
   version "0.5.19"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
   integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
@@ -8197,7 +8197,7 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
-source-map@^0.7.3:
+source-map@^0.7.3, source-map@~0.7.2:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
@@ -8636,14 +8636,14 @@ terminal-link@^2.0.0:
     ansi-escapes "^4.2.1"
     supports-hyperlinks "^2.0.0"
 
-terser@^4.8.0:
-  version "4.8.0"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-4.8.0.tgz#63056343d7c70bb29f3af665865a46fe03a0df17"
-  integrity sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==
+terser@^5.7.0:
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.7.0.tgz#a761eeec206bc87b605ab13029876ead938ae693"
+  integrity sha512-HP5/9hp2UaZt5fYkuhNBR8YyRcT8juw8+uFbAme53iN9hblvKnLUTKkmwJG6ocWpIKf8UK4DoeWG4ty0J6S6/g==
   dependencies:
     commander "^2.20.0"
-    source-map "~0.6.1"
-    source-map-support "~0.5.12"
+    source-map "~0.7.2"
+    source-map-support "~0.5.19"
 
 test-exclude@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
Terser 5 made the `minify()` method async. It's still the same fully synchronous code, just they updated their version of `source-map` to the one that uses WASM, which requires waiting for that to initialize.

---

**What's with the timings?** Originally, this upgrade caused all our `minify()` logs to show minification taking >1s, however after investigating and comparing with a modified synchronous version of Terser, this ended up being a miscalculation. Because Terser is still fully synchronous (we don't even hit the async codepath), timing the `await minify()` was effectively timing all enqueued minify() jobs. This happens because minify is an async function, but Rollup invokes `renderChunk()` in parallel within a synchronous loop. This loop basically enqueues a `minify()` task for all bundles up-front, and `await` only resolves once the queue is empty again.