### PR TITLE
Deprecate `options.aliases` in favor of `options.alias`

### DIFF
--- a/.changeset/light-flies-melt.md
+++ b/.changeset/light-flies-melt.md
@@ -1,0 +1,14 @@
+---
+'wmr': minor
+---
+
+Deprecate "aliases" configuration in favor of "alias" to have a consistent name across various frontend tools. The "aliases" property will continue to work, but a deprecation warning will be printed to the console.
+
+```diff
+export default {
+-	aliases: {
++	alias: {
+		react: 'preact/compat'
+	}
+};
+```

--- a/.changeset/silver-ways-lie.md
+++ b/.changeset/silver-ways-lie.md
@@ -9,7 +9,7 @@ Add support for importing files outside of the main public directory. This featu
 import { defineConfig } from 'wmr';
 
 export default defineConfig({
-	aliases: {
+	alias: {
 		// This will alias "~" to "<project>/src/components/"
 		'~/': './src/components/'
 	}

--- a/docs/public/content/docs/configuration.md
+++ b/docs/public/content/docs/configuration.md
@@ -138,7 +138,7 @@ Render bundle size statistics into an interactive `stats.html` file after `wmr b
 
 Print debugging messages intended for plugin authors to the terminal.
 
-### Aliases
+### Aliasing and Path-Mappings
 
 - Type: `{ string: string }`
 - Default: `{}`
@@ -149,7 +149,7 @@ Alias npm modules to different ones or use path mappings to shorten import speci
 import { defineConfig } from 'wmr';
 
 export default defineConfig({
-	aliases: {
+	alias: {
 		// Aliasing an npm module, in this case `react` to `preact/compat`
 		react: 'preact/compat'
 		// Aliasing `~` to a directory called `foo/`

--- a/examples/demo/wmr.config.ts
+++ b/examples/demo/wmr.config.ts
@@ -1,6 +1,6 @@
 export default function () {
 	return {
-		aliases: {
+		alias: {
 			'src/*': 'src'
 		}
 	};

--- a/packages/wmr/src/lib/aliasing.js
+++ b/packages/wmr/src/lib/aliasing.js
@@ -6,16 +6,16 @@ const logServe = debug('wmr:alias');
 
 /**
  * Potentially resolve an import specifier to an aliased url
- * @param {Record<string, string>} aliases
+ * @param {Record<string, string>} alias
  * @param {string} spec
  * @returns {string | undefined}
  */
-export function matchAlias(aliases, spec) {
-	for (let name in aliases) {
-		// Only check path-like aliases
+export function matchAlias(alias, spec) {
+	for (let name in alias) {
+		// Only check path-like alias mapping
 		if (!name.endsWith('/*')) continue;
 
-		const value = aliases[name];
+		const value = alias[name];
 
 		// Trim "*" at the end to get a valid path
 		name = name.slice(0, -1);
@@ -35,24 +35,24 @@ export function matchAlias(aliases, spec) {
 /**
  * Resolve an aliased url to an absolute file path, unless it's referring
  * to an npm module.
- * @param {Record<string, string>} aliases
+ * @param {Record<string, string>} alias
  * @param {string} url
  */
-export function resolveAlias(aliases, url) {
+export function resolveAlias(alias, url) {
 	if (url.startsWith('/@alias')) {
 		url = url.slice('/@alias'.length);
 	}
 
 	let partial = url;
-	for (let name in aliases) {
+	for (let name in alias) {
 		// Exact alias matches take precedence
-		if (url === name) return aliases[name];
+		if (url === name) return alias[name];
 
-		// Only check path-like aliases
+		// Only check path-like alias mapping
 		if (!name.endsWith('/*')) continue;
 
 		// Trim "*" at the end to get a valid path
-		const value = aliases[name];
+		const value = alias[name];
 		name = name.slice(0, -1);
 
 		if (partial === url && url.startsWith(name)) {

--- a/packages/wmr/src/lib/npm-middleware.js
+++ b/packages/wmr/src/lib/npm-middleware.js
@@ -6,7 +6,7 @@ import npmPlugin, { normalizeSpecifier } from '../plugins/npm-plugin/index.js';
 import { resolvePackageVersion, loadPackageFile } from '../plugins/npm-plugin/registry.js';
 import { getCachedBundle, setCachedBundle, sendCachedBundle, enqueueCompress } from './npm-middleware-cache.js';
 import processGlobalPlugin from '../plugins/process-global-plugin.js';
-import aliasesPlugin from '../plugins/aliases-plugin.js';
+import aliasPlugin from '../plugins/aliases-plugin.js';
 import { getMimeType } from './mimetypes.js';
 import nodeBuiltinsPlugin from '../plugins/node-builtins-plugin.js';
 import * as kl from 'kolorist';
@@ -36,12 +36,12 @@ async function handleAsset(meta, res) {
 /**
  * @param {object} [options]
  * @param {'npm'|'unpkg'} [options.source = 'npm'] How to fetch package files
- * @param {Record<string,string>} [options.aliases]
+ * @param {Record<string,string>} [options.alias]
  * @param {boolean} [options.optimize = true] Progressively minify and compress dependency bundles?
  * @param {string} [options.cwd] Virtual cwd
  * @returns {import('polka').Middleware}
  */
-export default function npmMiddleware({ source = 'npm', aliases, optimize, cwd } = {}) {
+export default function npmMiddleware({ source = 'npm', alias, optimize, cwd } = {}) {
 	return async (req, res, next) => {
 		// @ts-ignore
 		const mod = req.path.replace(/^\//, '');
@@ -77,7 +77,7 @@ export default function npmMiddleware({ source = 'npm', aliases, optimize, cwd }
 			if (cached) return sendCachedBundle(req, res, cached);
 
 			// const start = Date.now();
-			const code = await bundleNpmModule(mod, { source, aliases, cwd });
+			const code = await bundleNpmModule(mod, { source, alias, cwd });
 			// console.log(`Bundle dep: ${mod}: ${Date.now() - start}ms`);
 
 			// send it!
@@ -104,10 +104,10 @@ let npmCache;
  * @param {string} mod The module to bundle, including subpackage/path
  * @param {object} options
  * @param {'npm'|'unpkg'} [options.source]
- * @param {Record<string,string>} [options.aliases]
+ * @param {Record<string,string>} [options.alias]
  * @param {string} [options.cwd]
  */
-async function bundleNpmModule(mod, { source, aliases, cwd }) {
+async function bundleNpmModule(mod, { source, alias, cwd }) {
 	let npmProviderPlugin;
 
 	if (source === 'unpkg') {
@@ -133,7 +133,7 @@ async function bundleNpmModule(mod, { source, aliases, cwd }) {
 		preserveEntrySignatures: 'allow-extension',
 		plugins: [
 			nodeBuiltinsPlugin({}),
-			aliasesPlugin({ aliases, cwd }),
+			aliasPlugin({ alias, cwd }),
 			npmProviderPlugin,
 			processGlobalPlugin({
 				NODE_ENV: 'development'

--- a/packages/wmr/src/lib/output-utils.js
+++ b/packages/wmr/src/lib/output-utils.js
@@ -157,6 +157,14 @@ export function debug(namespace, color = selectColor(namespace)) {
 }
 
 /**
+ * Print a deprecation warning
+ * @param {string} message
+ */
+export function deprecated(message) {
+	console.log(kl.yellow(`Deprecated: ${message}`));
+}
+
+/**
  * Serialize path to display special characters such as
  * the null byte of necessary.
  * @param {string} path

--- a/packages/wmr/src/lib/plugins.js
+++ b/packages/wmr/src/lib/plugins.js
@@ -7,7 +7,7 @@ import npmPlugin from '../plugins/npm-plugin/index.js';
 import publicPathPlugin from '../plugins/public-path-plugin.js';
 import minifyCssPlugin from '../plugins/minify-css-plugin.js';
 import htmlEntriesPlugin from '../plugins/html-entries-plugin.js';
-import aliasesPlugin from '../plugins/aliases-plugin.js';
+import aliasPlugin from '../plugins/aliases-plugin.js';
 import processGlobalPlugin from '../plugins/process-global-plugin.js';
 import urlPlugin from '../plugins/url-plugin.js';
 import resolveExtensionsPlugin from '../plugins/resolve-extensions-plugin.js';
@@ -27,7 +27,7 @@ import { defaultLoaders } from './default-loaders.js';
  * @returns {import("wmr").Plugin[]}
  */
 export function getPlugins(options) {
-	const { plugins, cwd, publicPath, aliases, root, env, minify, mode, sourcemap, features, visualize } = options;
+	const { plugins, cwd, publicPath, alias, root, env, minify, mode, sourcemap, features, visualize } = options;
 
 	// Plugins are pre-sorted
 	let split = plugins.findIndex(p => p.enforce === 'post');
@@ -40,10 +40,10 @@ export function getPlugins(options) {
 		production && htmlEntriesPlugin({ cwd, publicPath }),
 		externalUrlsPlugin(),
 		nodeBuiltinsPlugin({ production }),
-		urlPlugin({ inline: !production, cwd, aliases }),
+		urlPlugin({ inline: !production, cwd, alias }),
 		jsonPlugin({ cwd }),
 		bundlePlugin({ inline: !production, cwd }),
-		aliasesPlugin({ aliases, cwd: root }),
+		aliasPlugin({ alias, cwd: root }),
 		sucrasePlugin({
 			typescript: true,
 			sourcemap,
@@ -56,7 +56,7 @@ export function getPlugins(options) {
 			}),
 		production && publicPathPlugin({ publicPath }),
 		sassPlugin({ production }),
-		production && wmrStylesPlugin({ hot: false, cwd, production, aliases }),
+		production && wmrStylesPlugin({ hot: false, cwd, production, alias }),
 		processGlobalPlugin({
 			env,
 			NODE_ENV: production ? 'production' : 'development'

--- a/packages/wmr/src/plugins/aliases-plugin.js
+++ b/packages/wmr/src/plugins/aliases-plugin.js
@@ -2,19 +2,19 @@ import { resolveAlias } from '../lib/aliasing.js';
 import { debug, formatResolved } from '../lib/output-utils.js';
 
 /**
- * Package.json "aliases" field: {"a":"b"}
+ * Package.json "alias" field: {"a":"b"}
  * @param {object} options
- * @param {Record<string,string>} options.aliases
+ * @param {Record<string,string>} options.alias
  * @returns {import('rollup').Plugin}
  */
-export default function aliasesPlugin({ aliases }) {
-	const log = debug('aliases');
+export default function aliasPlugin({ alias }) {
+	const log = debug('wmr:alias');
 
 	return {
-		name: 'aliases',
+		name: 'alias',
 		async resolveId(id, importer) {
 			if (typeof id !== 'string' || id.match(/^(\0|\.\.?\/)/)) return;
-			const aliased = resolveAlias(aliases, id);
+			const aliased = resolveAlias(alias, id);
 			if (aliased == null || aliased === id) return;
 
 			// now allow other resolvers to handle the aliased version

--- a/packages/wmr/src/plugins/url-plugin.js
+++ b/packages/wmr/src/plugins/url-plugin.js
@@ -12,10 +12,10 @@ const escapeUrl = url => url.replace(/#/g, '%23').replace(/'/g, "\\'").replace(/
  * @param {object} options
  * @param {object} [options.inline = false] Emit a Data URL module exporting the URL string.
  * @param {object} [options.cwd] Used to resolve the URL when `inline` is `true`.
- * @param {Record<string, string>} options.aliases
+ * @param {Record<string, string>} options.alias
  * @returns {import('rollup').Plugin}
  */
-export default function urlPlugin({ inline, cwd, aliases }) {
+export default function urlPlugin({ inline, cwd, alias }) {
 	const PREFIX = 'url:';
 	const INTERNAL_PREFIX = '\0url:';
 
@@ -33,7 +33,7 @@ export default function urlPlugin({ inline, cwd, aliases }) {
 
 			// In dev mode, we turn the import into an inline module that avoids a network request:
 			if (inline) {
-				const aliased = matchAlias(aliases, resolved.id);
+				const aliased = matchAlias(alias, resolved.id);
 				const url = (aliased || '/' + relative(cwd, resolved.id)) + '?asset';
 				log(`${kl.green('inline')} ${kl.dim(url)} <- ${kl.dim(resolved.id)}`);
 				return {

--- a/packages/wmr/src/plugins/wmr/styles-plugin.js
+++ b/packages/wmr/src/plugins/wmr/styles-plugin.js
@@ -98,10 +98,10 @@ export async function modularizeCss(css, id, mappings = [], idAbsolute) {
  * @param {boolean} [options.hot] Indicates the plugin should inject a HMR-runtime
  * @param {boolean} [options.fullPath] Preserve the full original path when producing CSS assets
  * @param {boolean} [options.production]
- * @param {Record<string, string>} options.aliases
+ * @param {Record<string, string>} options.alias
  * @returns {import('rollup').Plugin}
  */
-export default function wmrStylesPlugin({ cwd, hot, fullPath, production, aliases }) {
+export default function wmrStylesPlugin({ cwd, hot, fullPath, production, alias }) {
 	const cwds = new Set();
 
 	let assetId = 0;
@@ -125,7 +125,7 @@ export default function wmrStylesPlugin({ cwd, hot, fullPath, production, aliase
 			const isModular = /\.module\.(css|s[ac]ss)$/.test(id);
 
 			let idRelative = id;
-			let aliased = matchAlias(aliases, id);
+			let aliased = matchAlias(alias, id);
 			if (aliased) {
 				idRelative = aliased.slice('/@alias/'.length);
 			} else {

--- a/packages/wmr/src/server.js
+++ b/packages/wmr/src/server.js
@@ -26,9 +26,9 @@ import { hasDebugFlag } from './lib/output-utils.js';
  * @param {boolean} [options.http2 = false] Use HTTP/2
  * @param {boolean|number} [options.compress = true] Compress responses? Pass a `number` to set the size threshold.
  * @param {boolean} [options.optimize = true] Enable lazy dependency compression and optimization
- * @param {Record<string, string>} [options.aliases] module aliases
+ * @param {Record<string, string>} [options.alias] module or path alias mappings
  */
-export default async function server({ cwd, root, overlayDir, middleware, http2, compress = true, optimize, aliases }) {
+export default async function server({ cwd, root, overlayDir, middleware, http2, compress = true, optimize, alias }) {
 	try {
 		await fs.access(resolve(cwd, 'index.html'));
 	} catch (e) {
@@ -104,7 +104,7 @@ export default async function server({ cwd, root, overlayDir, middleware, http2,
 		app.use(compression({ threshold, level: 4 }));
 	}
 
-	app.use('/@npm', npmMiddleware({ aliases, optimize, cwd: root }));
+	app.use('/@npm', npmMiddleware({ alias, optimize, cwd: root }));
 
 	if (middleware) {
 		app.use(...middleware);

--- a/packages/wmr/src/wmr-middleware.js
+++ b/packages/wmr/src/wmr-middleware.js
@@ -32,7 +32,7 @@ export const moduleGraph = new Map();
  * @returns {import('polka').Middleware}
  */
 export default function wmrMiddleware(options) {
-	let { cwd, root, out, distDir = 'dist', onError, onChange = NOOP, aliases } = options;
+	let { cwd, root, out, distDir = 'dist', onError, onChange = NOOP, alias } = options;
 
 	distDir = resolve(dirname(out), distDir);
 
@@ -50,9 +50,9 @@ export default function wmrMiddleware(options) {
 	NonRollup.buildStart();
 
 	// Make watcher aware of aliased directories
-	const pathAliases = Object.keys(aliases)
+	const pathAliases = Object.keys(alias)
 		.filter(key => key.endsWith('/*'))
-		.map(key => aliases[key]);
+		.map(key => alias[key]);
 	const watchDirs = [cwd, resolve(root, 'package.json'), ...pathAliases];
 	logWatcher(`watching:\n${watchDirs.map(d => kl.dim('- ' + d)).join('\n')}`);
 
@@ -108,7 +108,7 @@ export default function wmrMiddleware(options) {
 		NonRollup.watchChange(absolute);
 
 		// Resolve potentially aliased paths and normalize to 'nix:
-		const aliased = matchAlias(aliases, absolute.split(sep).join(posix.sep));
+		const aliased = matchAlias(alias, absolute.split(sep).join(posix.sep));
 		filename = aliased
 			? // Trim leading slash, we need a relative path for the cache
 			  aliased.slice(1)
@@ -175,7 +175,7 @@ export default function wmrMiddleware(options) {
 			id = posix.normalize(path.slice('/@alias/'.length));
 
 			// Resolve to a file here for non-js Transforms
-			file = resolveAlias(options.aliases, id);
+			file = resolveAlias(options.alias, id);
 		} else {
 			const prefixMatches = path.match(/^\/?@([a-z-]+)(\/.+)$/);
 			if (prefixMatches) {
@@ -236,7 +236,7 @@ export default function wmrMiddleware(options) {
 				cwd,
 				out,
 				NonRollup,
-				aliases: options.aliases,
+				alias: options.alias,
 				cacheKey
 			});
 
@@ -273,10 +273,10 @@ export default function wmrMiddleware(options) {
  *
  * @param {string} file Path to file to load
  * @param {string} cwd
- * @param {Record<string, string>} aliases
+ * @param {Record<string, string>} alias
  * @returns
  */
-function resolveFile(file, cwd, aliases) {
+function resolveFile(file, cwd, alias) {
 	// Probably an error if we ar enot called with an absolute path
 	if (!isAbsolute(file)) {
 		throw new Error(`Expected absolute path but got: ${file}`);
@@ -299,8 +299,8 @@ function resolveFile(file, cwd, aliases) {
 		// TODO: Better to precompute this in normalizeOptions?
 		const includeDirs = [cwd];
 		// File is not in cwd, but might still be in an aliased directory
-		for (const alias in aliases) {
-			const value = aliases[alias];
+		for (const name in alias) {
+			const value = alias[name];
 
 			if (isAbsolute(value)) {
 				includeDirs.push(value);
@@ -329,7 +329,7 @@ function resolveFile(file, cwd, aliases) {
  * @property {string} prefix a Rollup plugin -style path `\0prefix:`, if the URL was `/＠prefix/*`
  * @property {string} cwd working directory, including ./public if detected
  * @property {string} out output directory
- * @property {Record<string, string>} aliases
+ * @property {Record<string, string>} alias
  * @property {string} cacheKey Key for write cache
  * @property {InstanceType<import('http')['IncomingMessage']>} req HTTP Request object
  * @property {InstanceType<import('http')['ServerResponse']>} res HTTP Response object
@@ -373,7 +373,7 @@ export const TRANSFORMS = {
 	},
 
 	// Handle individual JavaScript modules
-	async js({ id, file, prefix, res, cwd, out, NonRollup, req, aliases, cacheKey }) {
+	async js({ id, file, prefix, res, cwd, out, NonRollup, req, alias, cacheKey }) {
 		let code;
 		try {
 			res.setHeader('Content-Type', 'application/javascript;charset=utf-8');
@@ -395,7 +395,7 @@ export const TRANSFORMS = {
 				if (prefix) file = file.replace(prefix, '');
 				file = file.split(posix.sep).join(sep);
 				if (!isAbsolute(file)) file = resolve(cwd, file);
-				code = await fs.readFile(resolveFile(file, cwd, aliases), 'utf-8');
+				code = await fs.readFile(resolveFile(file, cwd, alias), 'utf-8');
 			}
 
 			code = await NonRollup.transform(code, id);
@@ -454,13 +454,13 @@ export const TRANSFORMS = {
 
 					// If file resolves outside of root it may be an aliased path.
 					if (spec.startsWith('.')) {
-						const aliased = matchAlias(aliases, posix.resolve(posix.dirname(file), spec));
+						const aliased = matchAlias(alias, posix.resolve(posix.dirname(file), spec));
 						if (aliased) spec = aliased;
 					}
 
 					if (!spec.startsWith('/@alias/') && !/^\0?\.?\.?[/\\]/.test(spec)) {
 						// Check if the spec is an alias
-						const aliased = matchAlias(aliases, spec);
+						const aliased = matchAlias(alias, spec);
 						if (aliased) spec = aliased;
 
 						if (!spec.startsWith('/@alias/')) {
@@ -522,7 +522,7 @@ export const TRANSFORMS = {
 		}
 	},
 	// Handles "CSS Modules" proxy modules (style.module.css.js)
-	async cssModule({ id, file, cwd, out, res, aliases, cacheKey }) {
+	async cssModule({ id, file, cwd, out, res, alias, cacheKey }) {
 		res.setHeader('Content-Type', 'application/javascript;charset=utf-8');
 
 		// Cache the generated mapping/proxy module with a .js extension (the CSS itself is also cached)
@@ -532,7 +532,7 @@ export const TRANSFORMS = {
 
 		// We create a plugin container for each request to prevent asset referenceId clashes
 		const container = createPluginContainer(
-			[wmrPlugin({ hot: true }), sassPlugin(), wmrStylesPlugin({ cwd, hot: true, fullPath: true, aliases })],
+			[wmrPlugin({ hot: true }), sassPlugin(), wmrStylesPlugin({ cwd, hot: true, fullPath: true, alias })],
 			{
 				cwd,
 				output: {
@@ -545,7 +545,7 @@ export const TRANSFORMS = {
 			}
 		);
 
-		const result = (await container.load(file)) || (await fs.readFile(resolveFile(file, cwd, aliases), 'utf-8'));
+		const result = (await container.load(file)) || (await fs.readFile(resolveFile(file, cwd, alias), 'utf-8'));
 
 		let code = typeof result === 'string' ? result : result && result.code;
 
@@ -568,7 +568,7 @@ export const TRANSFORMS = {
 	},
 
 	// Handles CSS Modules (the actual CSS)
-	async css({ id, path, file, cwd, out, res, aliases, cacheKey }) {
+	async css({ id, path, file, cwd, out, res, alias, cacheKey }) {
 		if (!/\.(css|s[ac]ss)$/.test(path)) throw null;
 
 		const isModular = /\.module\.(css|s[ac]ss)$/.test(path);
@@ -579,7 +579,7 @@ export const TRANSFORMS = {
 
 		if (WRITE_CACHE.has(id)) return WRITE_CACHE.get(id);
 
-		const idAbsolute = resolveFile(file, cwd, aliases);
+		const idAbsolute = resolveFile(file, cwd, alias);
 		let code = await fs.readFile(idAbsolute, 'utf-8');
 
 		if (isModular) {

--- a/packages/wmr/test/fixtures.test.js
+++ b/packages/wmr/test/fixtures.test.js
@@ -191,6 +191,20 @@ describe('fixtures', () => {
 			expect(await env.page.evaluate(`window.ReactDOM === window.preactCompat`)).toBe(true);
 		});
 
+		it('should warn when .aliases instead of .alias is found in config', async () => {
+			await loadFixture('alias-deprecated', env);
+			instance = await runWmrFast(env.tmp.path);
+			const output = await getOutput(env, instance);
+
+			await withLog(instance.output, async () => {
+				expect(output).toMatch(/preact was used to render/);
+				expect(await env.page.evaluate(`window.React === window.preactCompat`)).toBe(true);
+				expect(await env.page.evaluate(`window.ReactDOM === window.preactCompat`)).toBe(true);
+
+				expect(instance.output.join('\n')).toMatch(/Please switch to "alias"/);
+			});
+		});
+
 		it('should allow directory aliasing outside of cwd', async () => {
 			await loadFixture('alias-outside', env);
 			instance = await runWmrFast(env.tmp.path);

--- a/packages/wmr/test/fixtures/alias-asset/wmr.config.mjs
+++ b/packages/wmr/test/fixtures/alias-asset/wmr.config.mjs
@@ -1,5 +1,5 @@
 export default {
-	aliases: {
+	alias: {
 		'foo/': './foo'
 	}
 };

--- a/packages/wmr/test/fixtures/alias-css/wmr.config.mjs
+++ b/packages/wmr/test/fixtures/alias-css/wmr.config.mjs
@@ -1,5 +1,5 @@
 export default {
-	aliases: {
+	alias: {
 		'foo/*': 'foo'
 	}
 };

--- a/packages/wmr/test/fixtures/alias-deprecated/public/index.html
+++ b/packages/wmr/test/fixtures/alias-deprecated/public/index.html
@@ -1,0 +1,1 @@
+<script src="./index.js" type="module"></script>

--- a/packages/wmr/test/fixtures/alias-deprecated/public/index.js
+++ b/packages/wmr/test/fixtures/alias-deprecated/public/index.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import compat from 'preact/compat';
+import { options } from 'preact';
+
+window.React = React;
+window.ReactDOM = ReactDOM;
+window.preactCompat = compat;
+
+options.vnode = vnode => {
+	if (vnode.type === 'div') {
+		vnode.props.children = 'preact was used to render';
+	}
+};
+
+ReactDOM.render(React.createElement('div', null, 'react was used to render'), document.body);

--- a/packages/wmr/test/fixtures/alias-deprecated/wmr.config.mjs
+++ b/packages/wmr/test/fixtures/alias-deprecated/wmr.config.mjs
@@ -1,0 +1,6 @@
+export default {
+	aliases: {
+		react: 'preact/compat',
+		'react-dom': 'preact/compat'
+	}
+};

--- a/packages/wmr/test/fixtures/alias-outside/wmr.config.mjs
+++ b/packages/wmr/test/fixtures/alias-outside/wmr.config.mjs
@@ -1,5 +1,5 @@
 export default {
-	aliases: {
+	alias: {
 		'foo/*': './foo'
 	}
 };

--- a/packages/wmr/test/fixtures/alias-parent/wmr.config.mjs
+++ b/packages/wmr/test/fixtures/alias-parent/wmr.config.mjs
@@ -1,5 +1,5 @@
 export default {
-	aliases: {
+	alias: {
 		'parent/*': '../'
 	}
 };

--- a/packages/wmr/types.d.ts
+++ b/packages/wmr/types.d.ts
@@ -38,7 +38,11 @@ declare module 'wmr' {
 		out: string;
 		overlayDir: string;
 		sourcemap: boolean;
+		/**
+		 * @deprecated Please use `alias` instead
+		 */
 		aliases: Record<string, string>;
+		alias: Record<string, string>;
 		env: Record<string, string>;
 		middleware: Middleware[];
 		plugins: Plugin[];


### PR DESCRIPTION
As @rschristian noticed in #552 we sometimes check for `alias` and sometimes for `aliases`. We should only have one name for that feature. Just checked with other bundlers and the majorities use `alias`:

| Tool | Naming |
|---|---|
| [webpack](https://webpack.js.org/configuration/resolve/#resolvealias) | `alias` |
| [Parcel](https://parceljs.org/module_resolution.html#aliases) | `alias` |
| [vite](https://vitejs.dev/config/#resolve-alias) | `alias` |
| wmr | `alias` in `package.json`, otherwise `aliases` |

So to be consistent with everyone else (and ourselves), this PR deprecates `options.aliases` in favor of `options.alias`. Setting up aliasing via `options.aliases` will continue to work, but we'll print a deprecation warning to the console.

```bash
Deprecated: Found "aliases" property in WMR's configuration. It will be removed in a future version of WMR. Please switch to "alias" instead.
```