### PR TITLE
Fix/config extension priority

### DIFF
--- a/.changeset/shaggy-peaches-attend.md
+++ b/.changeset/shaggy-peaches-attend.md
@@ -1,0 +1,5 @@
+---
+'wmr': patch
+---
+
+Ensures TS wmr.config files are handled first

--- a/packages/wmr/src/lib/normalize-options.js
+++ b/packages/wmr/src/lib/normalize-options.js
@@ -78,7 +78,7 @@ export async function normalizeOptions(options, mode, configWatchFiles = []) {
 		// ignore error, reading aliases from package.json is an optional feature
 	}
 
-	const EXTENSIONS = ['.js', '.ts', '.mjs'];
+	const EXTENSIONS = ['.ts', '.js', '.mjs'];
 
 	let custom;
 	let initialError;


### PR DESCRIPTION
If there's an issue in the transpiled output, say like in #624, the user will have a `wmr.config.js` in addition to their `wmr.config.ts`, as WMR encountered an error before it could clean that up.

With the existing priority, WMR would end up using that broken output before trying to use the `.ts` config. Users would have to manually remove the bad file before starting WMR again to ensure a clean run.