### PR TITLE
Fix broken docs build

### DIFF
--- a/.changeset/sixty-needles-change.md
+++ b/.changeset/sixty-needles-change.md
@@ -1,0 +1,5 @@
+---
+'wmr': patch
+---
+
+Ensure options.cwd is correct after plugin passes


### PR DESCRIPTION
This was an interesting one! Essentially we land in an undefined situation with our current plugin system. We pass the options object directly to the configuration to plugins, but we ignore the fact that plugins may lazily change them. This leads to an awkward scenario where the passed reference may get out of sync.

```js
export function options => {
  myPlugin(options.cwd) // out of sync
}
```

This requires a bit more brain power to solve once and for all, but for now this PR gets our docs site up and running again.