### PR TITLE
Only load first matching config file

### DIFF
--- a/.changeset/modern-dolphins-talk.md
+++ b/.changeset/modern-dolphins-talk.md
@@ -1,0 +1,5 @@
+---
+'wmr': patch
+---
+
+Fix unable to start when multiple config files in different formats are present.

--- a/packages/wmr/src/lib/normalize-options.js
+++ b/packages/wmr/src/lib/normalize-options.js
@@ -125,6 +125,9 @@ export async function normalizeOptions(options, mode, configWatchFiles = []) {
 				// the URL.
 				const importSource = supportsSearchParams ? `(x => import(x + '?t=${Date.now()}'))` : `(x => import(x))`;
 				custom = await eval(importSource)(fileUrl.toString());
+
+				// We found our config file
+				break;
 			} catch (err) {
 				console.log(err);
 				initialError = err;

--- a/packages/wmr/test/fixtures.test.js
+++ b/packages/wmr/test/fixtures.test.js
@@ -886,6 +886,14 @@ describe('fixtures', () => {
 			await waitForMessage(instance.output, /foo/);
 			expect(true).toEqual(true); // Silence linter
 		});
+
+		it('should only load TypeScript config', async () => {
+			await loadFixture('config-multiple', env);
+			instance = await runWmrFast(env.tmp.path);
+
+			await waitForMessage(instance.output, /plugin-ts/);
+			expect(true).toEqual(true); // Silence linter
+		});
 	});
 
 	describe('plugins', () => {

--- a/packages/wmr/test/fixtures/config-multiple/index.html
+++ b/packages/wmr/test/fixtures/config-multiple/index.html
@@ -1,0 +1,1 @@
+<h1>Hello world</h1>

--- a/packages/wmr/test/fixtures/config-multiple/wmr.config.js
+++ b/packages/wmr/test/fixtures/config-multiple/wmr.config.js
@@ -1,0 +1,5 @@
+module.exports = () => {
+	return {
+		plugins: [{ name: 'plugin-cjs' }]
+	};
+};

--- a/packages/wmr/test/fixtures/config-multiple/wmr.config.mjs
+++ b/packages/wmr/test/fixtures/config-multiple/wmr.config.mjs
@@ -1,0 +1,5 @@
+export default function () {
+	return {
+		plugins: [{ name: 'plugin-mjs' }]
+	};
+}

--- a/packages/wmr/test/fixtures/config-multiple/wmr.config.ts
+++ b/packages/wmr/test/fixtures/config-multiple/wmr.config.ts
@@ -1,0 +1,5 @@
+export default function () {
+	return {
+		plugins: [{ name: 'plugin-ts' }]
+	};
+}


### PR DESCRIPTION
Fixes the following error:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/Users/marvinhagemeister/dev/github/wmr/examples/demo/wmr.config.js' imported from /Users/marvinhagemeister/dev/github/wmr/packages/wmr/src/lib/normalize-options.js
    at new NodeError (node:internal/errors:329:5)
    at finalizeResolution (node:internal/modules/esm/resolve:323:11)
    at moduleResolve (node:internal/modules/esm/resolve:758:10)
    at Loader.defaultResolve [as _resolve] (node:internal/modules/esm/resolve:869:11)
    at Loader.resolve (node:internal/modules/esm/loader:86:40)
    at Loader.getModuleJob (node:internal/modules/esm/loader:230:28)
    at Loader.import (node:internal/modules/esm/loader:165:28)
    at importModuleDynamically (node:internal/modules/esm/translators:116:35)
    at exports.importModuleDynamicallyCallback (node:internal/process/esm_loader:30:14)
    at eval (eval at normalizeOptions (file:///Users/marvinhagemeister/dev/github/wmr/packages/wmr/src/lib/normalize-options.js:128:20), <anonymous>:1:16) {
  code: 'ERR_MODULE_NOT_FOUND'
}

Error: Failed to load wmr.config.js
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/Users/marvinhagemeister/dev/github/wmr/examples/demo/wmr.config.js' imported from /Users/marvinhagemeister/dev/github/wmr/packages/wmr/src/lib/normalize-options.js
ReferenceError: require is not defined
```