### PR TITLE
Fix relative import specifiers becoming bare in development

### DIFF
--- a/.changeset/ninety-cherries-hammer.md
+++ b/.changeset/ninety-cherries-hammer.md
@@ -1,0 +1,5 @@
+---
+'wmr': patch
+---
+
+Fix `./` not preserved during development for `resolveId()` plugin hook

--- a/packages/wmr/test/fixtures.test.js
+++ b/packages/wmr/test/fixtures.test.js
@@ -899,6 +899,20 @@ describe('fixtures', () => {
 	});
 
 	describe('plugins', () => {
+		it("should preserve './' for relative specifiers", async () => {
+			await loadFixture('plugin-resolve', env);
+			instance = await runWmrFast(env.tmp.path);
+			const output = await getOutput(env, instance);
+			expect(output).toMatch(/Resolved: \.\/foo\.js/);
+		});
+
+		it("should preserve './' for relative specifiers with prefixes", async () => {
+			await loadFixture('plugin-resolve-prefix', env);
+			instance = await runWmrFast(env.tmp.path);
+			const output = await getOutput(env, instance);
+			expect(output).toMatch(/Resolved: url:\.\/foo\.js/);
+		});
+
 		it('should order by plugin.enforce value', async () => {
 			await loadFixture('plugin-enforce', env);
 			instance = await runWmrFast(env.tmp.path);

--- a/packages/wmr/test/fixtures/plugin-resolve-prefix/public/index.html
+++ b/packages/wmr/test/fixtures/plugin-resolve-prefix/public/index.html
@@ -1,0 +1,2 @@
+<h1>it doesn't work</h1>
+<script type="module" src="./index.js"></script>

--- a/packages/wmr/test/fixtures/plugin-resolve-prefix/public/index.js
+++ b/packages/wmr/test/fixtures/plugin-resolve-prefix/public/index.js
@@ -1,0 +1,3 @@
+import { value } from 'url:./foo.js';
+
+document.querySelector('h1').textContent = `Resolved: ${value}`;

--- a/packages/wmr/test/fixtures/plugin-resolve-prefix/wmr.config.mjs
+++ b/packages/wmr/test/fixtures/plugin-resolve-prefix/wmr.config.mjs
@@ -1,0 +1,21 @@
+export default function foo() {
+	let resolved = '';
+	return {
+		plugins: [
+			{
+				name: 'resolve-id',
+				resolveId(id) {
+					if (/foo/.test(id)) {
+						resolved = id;
+						return id;
+					}
+				},
+				load(id) {
+					if (/foo/.test(id)) {
+						return `export const value = ${JSON.stringify(resolved.replace('\0', ''))}`;
+					}
+				}
+			}
+		]
+	};
+}

--- a/packages/wmr/test/fixtures/plugin-resolve/public/index.html
+++ b/packages/wmr/test/fixtures/plugin-resolve/public/index.html
@@ -1,0 +1,2 @@
+<h1>it doesn't work</h1>
+<script type="module" src="./index.js"></script>

--- a/packages/wmr/test/fixtures/plugin-resolve/public/index.js
+++ b/packages/wmr/test/fixtures/plugin-resolve/public/index.js
@@ -1,0 +1,3 @@
+import { value } from './foo.js';
+
+document.querySelector('h1').textContent = `Resolved: ${value}`;

--- a/packages/wmr/test/fixtures/plugin-resolve/wmr.config.mjs
+++ b/packages/wmr/test/fixtures/plugin-resolve/wmr.config.mjs
@@ -1,0 +1,21 @@
+export default function foo() {
+	let resolved = '';
+	return {
+		plugins: [
+			{
+				name: 'resolve-id',
+				resolveId(id) {
+					if (/foo/.test(id)) {
+						resolved = id;
+						return id;
+					}
+				},
+				load(id) {
+					if (/foo/.test(id)) {
+						return `export const value = ${JSON.stringify(resolved.replace('\0', ''))}`;
+					}
+				}
+			}
+		]
+	};
+}

--- a/packages/wmr/test/production.test.js
+++ b/packages/wmr/test/production.test.js
@@ -107,6 +107,46 @@ describe('production', () => {
 		expect(text).toMatch(/it works/);
 	});
 
+	it("should preserve './' for relative specifiers", async () => {
+		await loadFixture('plugin-resolve', env);
+		instance = await runWmr(env.tmp.path, 'build');
+
+		await withLog(instance.output, async () => {
+			const code = await instance.done;
+			expect(code).toEqual(0);
+
+			const { address, stop } = serveStatic(path.join(env.tmp.path, 'dist'));
+			cleanup.push(stop);
+
+			await env.page.goto(address, {
+				waitUntil: ['networkidle0', 'load']
+			});
+
+			const output = await env.page.content();
+			expect(output).toMatch(/Resolved: \.\/foo\.js/);
+		});
+	});
+
+	it("should preserve './' for relative specifiers with prefixes", async () => {
+		await loadFixture('plugin-resolve-prefix', env);
+		instance = await runWmr(env.tmp.path, 'build');
+
+		await withLog(instance.output, async () => {
+			const code = await instance.done;
+			expect(code).toEqual(0);
+
+			const { address, stop } = serveStatic(path.join(env.tmp.path, 'dist'));
+			cleanup.push(stop);
+
+			await env.page.goto(address, {
+				waitUntil: ['networkidle0', 'load']
+			});
+
+			const output = await env.page.content();
+			expect(output).toMatch(/Resolved: url:\.\/foo\.js/);
+		});
+	});
+
 	describe('alias', () => {
 		it('should alias directories', async () => {
 			await loadFixture('alias-outside', env);


### PR DESCRIPTION
This PR ensures that we keep passing relative import specifiers to resolveId. Previously we'd loose the leading `./`, leading to `./foo.js` being passed as `foo.js` during development.

This is a necessary precursor step towards turning the npm middleware into a standard plugin.