### PR TITLE
Never copy wmr.config.js to output directory

### DIFF
--- a/.changeset/eight-peas-reflect.md
+++ b/.changeset/eight-peas-reflect.md
@@ -1,0 +1,5 @@
+---
+"wmr": patch
+---
+
+Never copy `wmr.config.js` to output directory

--- a/packages/wmr/src/plugins/copy-assets-plugin.js
+++ b/packages/wmr/src/plugins/copy-assets-plugin.js
@@ -10,6 +10,9 @@ const IGNORE_FILES = [
 	'yarn.lock',
 	'tsconfig.json',
 	'babel.config.js',
+	'wmr.config.mjs',
+	'wmr.config.js',
+	'wmr.config.ts',
 	'/dist',
 	'/build'
 ];


### PR DESCRIPTION
This happens when there is no `public` or `src` dir.