### PR TITLE
fix(polkompress): avoid hanging requests and/or runtime errors

### DIFF
--- a/.changeset/hungry-students-pump.md
+++ b/.changeset/hungry-students-pump.md
@@ -1,0 +1,5 @@
+---
+'wmr': patch
+---
+
+fix(compression): ensure all responses write headers

--- a/packages/wmr/src/lib/polkompress.js
+++ b/packages/wmr/src/lib/polkompress.js
@@ -67,7 +67,7 @@ export default function compression({ threshold = 1024, level = -1, brotli = fal
 				listeners.forEach(p => on.apply(res, p));
 			}
 
-			if (pendingStatus) writeHead.call(res, pendingStatus);
+			writeHead.call(res, pendingStatus || res.statusCode);
 		}
 
 		const { end, write, on, writeHead } = res;

--- a/packages/wmr/test/lib/polkompress.test.js
+++ b/packages/wmr/test/lib/polkompress.test.js
@@ -23,7 +23,7 @@ function setup(handler) {
 			return new Promise(res => {
 				server.listen(() => {
 					let info = server.address();
-					let port = /** @type {import('net').AddressInfo} */(info).port;
+					let port = /** @type {import('net').AddressInfo} */ (info).port;
 					return res(`http://localhost:${port}`);
 				});
 			});
@@ -34,7 +34,7 @@ function setup(handler) {
 	};
 }
 
-describe.only('polkompress', () => {
+describe('polkompress', () => {
 	it('should be a function', () => {
 		expect(typeof compression).toBe('function');
 	});

--- a/packages/wmr/test/lib/polkompress.test.js
+++ b/packages/wmr/test/lib/polkompress.test.js
@@ -1,0 +1,127 @@
+import { createServer } from 'http';
+import compression from '../../src/lib/polkompress.js';
+import { get } from '../test-helpers.js';
+
+/**
+ * @param {string} address
+ * @param {string} [pathname]
+ */
+function send(address, pathname = '/') {
+	let ctx = /** @type {*} */ ({ address });
+	return get(ctx, pathname);
+}
+
+function setup(handler) {
+	let mware = compression({ level: 1, threshold: 4 });
+	let server = createServer((req, res) => {
+		req.headers['accept-encoding'] = 'gzip';
+		res.setHeader('content-type', 'text/plain');
+		mware(req, res, () => handler(req, res));
+	});
+	return {
+		listen() {
+			return new Promise(res => {
+				server.listen(() => {
+					let info = server.address();
+					let port = /** @type {import('net').AddressInfo} */(info).port;
+					return res(`http://localhost:${port}`);
+				});
+			});
+		},
+		close() {
+			server.close();
+		}
+	};
+}
+
+describe.only('polkompress', () => {
+	it('should be a function', () => {
+		expect(typeof compression).toBe('function');
+	});
+
+	it('should return a function', () => {
+		expect(typeof compression()).toBe('function');
+	});
+
+	it('should allow server to work if not compressing', async () => {
+		const server = setup((r, res) => {
+			res.end('OK');
+		});
+
+		try {
+			const address = await server.listen();
+			const output = await send(address);
+			expect(output.status).toBe(200);
+			expect(output.body).toBe('OK');
+
+			const headers = output.res.headers;
+			expect(headers['content-type']).toBe('text/plain');
+			expect(headers['content-encoding']).toBe(undefined);
+			expect(headers['transfer-encoding']).toBe('chunked');
+			expect(headers['content-length']).toBe(undefined);
+		} finally {
+			server.close();
+		}
+	});
+
+	it('should compress body when over threshold', async () => {
+		const server = setup((r, res) => {
+			res.end('HELLO WORLD');
+		});
+
+		try {
+			const address = await server.listen();
+			const output = await send(address);
+			expect(output.status).toBe(200);
+			expect(output.body).not.toBe('HELLO WORLD');
+
+			const headers = output.res.headers;
+			expect(headers['content-type']).toBe('text/plain');
+			expect(headers['content-encoding']).toBe('gzip');
+			expect(headers['transfer-encoding']).toBe('chunked');
+			expect(headers['content-length']).toBe(undefined);
+		} finally {
+			server.close();
+		}
+	});
+
+	it('should respect custom `statusCode` when set :: enabled', async () => {
+		const server = setup((r, res) => {
+			res.statusCode = 201;
+			res.end('HELLO WORLD');
+		});
+
+		try {
+			const address = await server.listen();
+			const output = await send(address);
+			expect(output.status).toBe(201);
+			expect(output.body).not.toBe('HELLO WORLD');
+
+			const headers = output.res.headers;
+			expect(headers['content-encoding']).toBe('gzip');
+			expect(headers['transfer-encoding']).toBe('chunked');
+		} finally {
+			server.close();
+		}
+	});
+
+	it('should respect custom `statusCode` when set :: disabled', async () => {
+		const server = setup((r, res) => {
+			res.statusCode = 201;
+			res.end('OK');
+		});
+
+		try {
+			const address = await server.listen();
+			const output = await send(address);
+			expect(output.status).toBe(201);
+			expect(output.body).toBe('OK');
+
+			const headers = output.res.headers;
+			expect(headers['content-encoding']).toBe(undefined);
+			expect(headers['transfer-encoding']).toBe('chunked');
+		} finally {
+			server.close();
+		}
+	});
+});


### PR DESCRIPTION
Ok, this one is a little long-winded:

The `polkompress` middleware didn't always "cleanup"/terminate the response correctly. Basically, our monkey-patched `res.writeHead` held a dangling `pendingStatus` value for when `start()` was done. However, this only worked if there was an _explicit_ call to `res.writeHead` somewhere in the application _before_ the `start()` exits.

I don't know if this just has to do with the fact that my test case used a small `body`  (even when crossing the threshold) , but in my reproductions I saw that this was always the order:

```js
INSIDE END // via res.end patch
START END { pendingStatus: undefined } // last line of start()
INSIDE WRITEHEAD 200 // via res.writeHead patch
```

So, the `res.writeHead` call that `res.end` makes internally (native, not patched behavior) happens after `start()` has already finished. This problem manifested as two different errors:

1) When body was shorter than the threshold, it results in a hanging request that never terminates – at least until timeout takes over

2) When the body crosses the threshold (and _does not_ take a while to finish compressing, I guess), this nasty error surfaces, which was seen in production (repro below):

![Screen_Shot_2021-05-26_at_8 27 29_PM](https://user-images.githubusercontent.com/5855893/119767262-63330c00-be6b-11eb-93db-e9649993f45e.png)

You can get to both errors with this snippet & by playing with the `res.end` contents:

```js
http.createServer((req, res) => {
  compression({ level: 1, threshold: 4 })(req, res, () => {
    res.end("OK");
    // res.end("HELLO WORLD");
  })
}).listen(3000);
```

I added tests (nearly crashed my computer, twice!!) for both variants of this error.