### PR TITLE
Do not inject link tag if entry css not exists

### DIFF
--- a/.changeset/sour-keys-attend.md
+++ b/.changeset/sour-keys-attend.md
@@ -1,0 +1,5 @@
+---
+"wmr": patch
+---
+
+Do not inject `<link rel=stylesheet>` when there is no stylesheet.

--- a/packages/wmr/src/plugins/optimize-graph-plugin.js
+++ b/packages/wmr/src/plugins/optimize-graph-plugin.js
@@ -269,9 +269,10 @@ async function hoistEntryCss(graph) {
 					const entry = graph.bundle[jsEntry];
 					if (entry.isEntry) {
 						const cssFile = entry.referencedFiles.find(f => f.endsWith('.css'));
-						// Ignore if no entry css
+
+						// Ignore if no entry css:
 						if (!cssFile) continue;
-						
+
 						asset.referencedFiles.push(cssFile);
 
 						asset.source = await injectHead(asset.source, {

--- a/packages/wmr/src/plugins/optimize-graph-plugin.js
+++ b/packages/wmr/src/plugins/optimize-graph-plugin.js
@@ -269,6 +269,9 @@ async function hoistEntryCss(graph) {
 					const entry = graph.bundle[jsEntry];
 					if (entry.isEntry) {
 						const cssFile = entry.referencedFiles.find(f => f.endsWith('.css'));
+						// Ignore if no entry css
+						if (!cssFile) continue;
+						
 						asset.referencedFiles.push(cssFile);
 
 						asset.source = await injectHead(asset.source, {


### PR DESCRIPTION
If `/public/index.html` does not have entry CSS file like this..

```html
<!DOCTYPE html>
<html lang="en">
	<head>
		<meta charset="utf-8">
		<title>repro</title>
	</head>
	<body>
		<script type="module" src="/index.js"></script>
	</body>
</html>
```

w/ minimal `/public/index.js`.

```js
import { hydrate, prerender as ssr } from 'preact-iso';

const App = () => <h1>Hello World!</h1>;

hydrate(<App />);

export const prerender = async (data) => ssr(<App {...data} />);
```

`wmr build --prerender` generates this HTML.

```html
<!DOCTYPE html>
<html lang="en">
	<head>
		<meta charset="utf-8">
		<title>repro</title>

		<link rel="stylesheet" href="/undefined"> <!-- 👀 -->
</head>
	<body><h1>Hello World!</h1>
		<script type="module" src="/index.68215b6e.js"></script>
	</body>
</html>
```

This empty `link` element should not be injected. Does this change make sense?