### PR TITLE
Terser's typings are (technically) correct

### DIFF
--- a/packages/wmr/src/plugins/fast-minify.js
+++ b/packages/wmr/src/plugins/fast-minify.js
@@ -33,7 +33,6 @@ export default function fastMinifyPlugin({ sourcemap = false, warnThreshold = 50
 				return this.error(err);
 			}
 
-			// TODO: Check if tersers typings are wrong
 			if (!out.code) out.code = code;
 
 			if (duration > warnThreshold && hasDebugFlag()) {


### PR DESCRIPTION
There's an undocumented option, `options.format.code`, which you can set to false to have Terser not output any code. In that case `out.code` is indeed undefined. It can be used if you're interested in the ESTree AST only (it's helpful if you want to do further processing to the code).

Side note, the Rust port of Terser built by the SWC project (which I've been neglecting a bit but I try to help out) is approaching a ready status. If you'd like to access an experimental version, let me know.

Much love!