### PR TITLE
chore: Init'd create-wmr app is private by default

### DIFF
--- a/.changeset/early-vans-fail.md
+++ b/.changeset/early-vans-fail.md
@@ -1,0 +1,5 @@
+---
+'create-wmr': patch
+---
+
+Marks newly created apps as private

--- a/packages/create-wmr/tpl/package.json
+++ b/packages/create-wmr/tpl/package.json
@@ -1,4 +1,5 @@
 {
+	"private": true,
 	"scripts": {
 		"start": "wmr",
 		"build": "wmr build --prerender",


### PR DESCRIPTION
Probably fair to mark newly created wmr apps as being private, not for publish on NPM

Yarn will alert the user to this on every single command, which tends to get mildly annoying after a certain point