### PR TITLE
chore: Remove unused 'useEffect' import in preact-iso/router

### DIFF
--- a/packages/preact-iso/router.js
+++ b/packages/preact-iso/router.js
@@ -1,5 +1,5 @@
 import { h, createContext, cloneElement, toChildArray } from 'preact';
-import { useContext, useMemo, useReducer, useEffect, useLayoutEffect, useRef } from 'preact/hooks';
+import { useContext, useMemo, useReducer, useLayoutEffect, useRef } from 'preact/hooks';
 
 let push;
 const UPDATE = (state, url) => {


### PR DESCRIPTION
Besides simply being unused, it causes this message in any new app / any app that uses `preact-iso/router`, which isn't really helpful.

![temp](https://user-images.githubusercontent.com/33403762/120718411-d4d41100-c48e-11eb-83a2-52838638a0ee.png)