### PR TITLE
Refactor/shared tooling

### DIFF
--- a/.changeset/wicked-ties-learn.md
+++ b/.changeset/wicked-ties-learn.md
@@ -1,0 +1,5 @@
+---
+'preact-iso': patch
+---
+
+Removing unused imports (and associated console warnings) in preact-iso

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,16 +45,16 @@ jobs:
         run: yarn --frozen-lockfile
       - name: Build
         if: ${{ needs.changes.outputs.wmr == 'true' }}
-        run: yarn workspace wmr build
+        run: yarn wmr build
       - name: Test wmr
         if: ${{ needs.changes.outputs.wmr == 'true' }}
-        run: yarn workspace wmr test
+        run: yarn eslint packages/wmr && yarn wmr test
       - name: Test wmr (production build)
         if: ${{ needs.changes.outputs.wmr == 'true' }}
-        run: yarn workspace wmr test-prod
+        run: yarn wmr test-prod
       - name: Test preact-iso
         if: ${{ needs.changes.outputs.preact-iso == 'true' }}
-        run: yarn workspace preact-iso test
+        run: yarn eslint packages/preact-iso && yarn iso test
 
   lhci:
     needs: changes

--- a/package.json
+++ b/package.json
@@ -83,9 +83,6 @@
 			"pre-commit": "lint-staged"
 		}
 	},
-	"jest": {
-		"preset": "jest-puppeteer"
-	},
 	"devDependencies": {
 		"@changesets/changelog-github": "^0.2.7",
 		"@changesets/cli": "^2.12.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
 		"ci": "yarn wmr build && yarn --check-files && yarn demo build:prod"
 	},
 	"eslintConfig": {
-		"ignorePatterns": "packages/wmr/test/fixtures/**",
 		"extends": [
 			"developit",
 			"prettier",
@@ -30,7 +29,7 @@
 			"import"
 		],
 		"rules": {
-			"no-console": "off",
+			"no-console": "error",
 			"prefer-rest-params": "off",
 			"prefer-spread": "off",
 			"no-prototype-builtins": "off",
@@ -54,8 +53,8 @@
 		}
 	},
 	"eslintIgnore": [
-		"*.cjs",
-		"*.ts",
+		"**/*.ts",
+		"packages/wmr/wmr.cjs",
 		"packages/wmr/test/fixtures/**/*.expected.*",
 		"packages/wmr/test/fixtures/*/dist",
 		"packages/wmr/test/fixtures/*/.cache"

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
 		"arrowParens": "avoid"
 	},
 	"lint-staged": {
-		"packages/**/{src,test}/**/*.js": [
+		"packages/**/*.{js,ts}": [
 			"eslint --fix",
 			"prettier --write"
 		],

--- a/package.json
+++ b/package.json
@@ -55,9 +55,7 @@
 	"eslintIgnore": [
 		"**/*.ts",
 		"packages/wmr/wmr.cjs",
-		"packages/wmr/test/fixtures/**/*.expected.*",
-		"packages/wmr/test/fixtures/*/dist",
-		"packages/wmr/test/fixtures/*/.cache"
+		"packages/wmr/test/fixtures/**"
 	],
 	"prettier": {
 		"singleQuote": true,

--- a/packages/preact-iso/hydrate.d.ts
+++ b/packages/preact-iso/hydrate.d.ts
@@ -1,3 +1,3 @@
-import { ComponentChild, VNode } from 'preact';
+import { ComponentChild } from 'preact';
 
 export default function hydrate(jsx: ComponentChild, parent?: Element | Document | ShadowRoot | DocumentFragment): void;

--- a/packages/preact-iso/router.js
+++ b/packages/preact-iso/router.js
@@ -1,5 +1,5 @@
 import { h, createContext, cloneElement, toChildArray } from 'preact';
-import { useContext, useMemo, useReducer, useEffect, useLayoutEffect, useRef } from 'preact/hooks';
+import { useContext, useMemo, useReducer, useLayoutEffect, useRef } from 'preact/hooks';
 
 let push;
 const UPDATE = (state, url) => {

--- a/packages/wmr/package.json
+++ b/packages/wmr/package.json
@@ -9,10 +9,9 @@
 		"prepublishOnly": "yarn build",
 		"prepack": "node --experimental-modules ./src/lib/~publish.js",
 		"postpack": "mv -f .package.json package.json",
-		"lint": "eslint src test",
 		"test-e2e": "cross-env JEST_PUPPETEER_CONFIG=jest-puppeteer.config.cjs jest",
 		"test-prod": "cross-env PRODUCTION_BUILD=true JEST_PUPPETEER_CONFIG=jest-puppeteer.config.cjs jest",
-		"test": "npm run lint && npm run test-e2e",
+		"test": "npm run test-e2e",
 		"fixture": "node tools/run-fixture.js"
 	},
 	"author": "The Preact Authors (https://preactjs.com)",
@@ -29,67 +28,6 @@
 		"plugins": [
 			"@babel/plugin-transform-modules-commonjs"
 		]
-	},
-	"eslintConfig": {
-		"extends": [
-			"developit",
-			"prettier",
-			"plugin:prettier/recommended"
-		],
-		"plugins": [
-			"prettier",
-			"import"
-		],
-		"rules": {
-			"no-console": 2,
-			"prefer-rest-params": "off",
-			"prefer-spread": "off",
-			"no-prototype-builtins": "off",
-			"function-call-argument-newline": [
-				"error",
-				"consistent"
-			],
-			"react/jsx-no-bind": "off",
-			"import/extensions": [
-				"error",
-				"always",
-				{
-					"ignorePackages": true
-				}
-			]
-		},
-		"globals": {
-			"jestPuppeteer": "readonly",
-			"browser": "readonly",
-			"page": "readonly"
-		}
-	},
-	"eslintIgnore": [
-		"wmr.cjs",
-		"test/fixtures/**/*.expected.*",
-		"test/fixtures/*/dist",
-		"test/fixtures/*/.cache"
-	],
-	"prettier": {
-		"singleQuote": true,
-		"trailingComma": "none",
-		"useTabs": true,
-		"printWidth": 120,
-		"arrowParens": "avoid"
-	},
-	"lint-staged": {
-		"{src,test}/**/*.js": [
-			"eslint --fix",
-			"prettier --write"
-		],
-		"*.md": [
-			"prettier --write"
-		]
-	},
-	"husky": {
-		"hooks": {
-			"pre-commit": "lint-staged"
-		}
 	},
 	"jest": {
 		"preset": "jest-puppeteer"
@@ -119,16 +57,9 @@
 		"devcert": "^1.1.2",
 		"errorstacks": "^2.3.2",
 		"es-module-lexer": "^0.4.1",
-		"eslint": "^7.4.0",
-		"eslint-config-developit": "^1.2.0",
-		"eslint-config-prettier": "^6.11.0",
-		"eslint-plugin-import": "^2.22.0",
-		"eslint-plugin-prettier": "^3.1.4",
-		"husky": "^4.2.5",
 		"jest": "^26.1.0",
 		"jest-puppeteer": "^4.4.0",
 		"kolorist": "^1.3.2",
-		"lint-staged": "^10.2.11",
 		"magic-string": "^0.25.7",
 		"ncp": "^2.0.0",
 		"node-fetch": "^2.6.1",
@@ -137,7 +68,6 @@
 		"postcss": "^7.0.32",
 		"postcss-es6": "github:postcss/postcss#7.0.32",
 		"posthtml": "0.13.1",
-		"prettier": "^2.0.5",
 		"puppeteer": "^3.3.0",
 		"resolve.exports": "^1.0.2",
 		"rollup": "^2.43.1",


### PR DESCRIPTION
Stems from #664, an issue that ESLint would've caught had it been set up.

- Removes ESLint, Husky, and Prettier config from `packages/wmr`. It's all duplicated at the package root. We don't need it.
- Updates workflows
- Fixes low-hanging linting issues in `preact-iso`
- Includes `.ts` files in pre-commit hook so no more needing to run `prettier` manually on them