### PR TITLE
Docs: Fix anchor links hidden behind header

### DIFF
--- a/docs/plugins/markdown.js
+++ b/docs/plugins/markdown.js
@@ -17,8 +17,8 @@ marked.use({
 				.replace(/[^\w]+/g, '-')
 				.replace(/[-]+$/g, '');
 
-			return `<h${level}>
-			<a id="${escapedText}" class="anchor" href="#${escapedText}">#</a>
+			return `<h${level} id="${escapedText}">
+			<a class="anchor" href="#${escapedText}">#</a>
 			${text}
 		</h${level}>`;
 		}

--- a/docs/public/styles/index.css
+++ b/docs/public/styles/index.css
@@ -118,6 +118,14 @@ body {
 	transition: background 0.3s;
 }
 
+/* Prevent fixed header from overlapping anchors */
+:target::before {
+	content: '';
+	display: block;
+	height: calc(1rem + var(--header-height));
+	margin: calc(-1 * calc(1rem + var(--header-height))) 0 0;
+}
+
 /** Wraps the content */
 #page {
 	outline: none;


### PR DESCRIPTION
When clicking on an anchor link the target headline was always hidden behind our fixed header. With some CSS magic we can add an offset to the scroll position to ensure the headline is in the visible area.

Before:

<img width="837" alt="Screenshot 2021-06-05 at 11 11 33" src="https://user-images.githubusercontent.com/1062408/120886553-e2081180-c5ee-11eb-8c6e-c53db655f6ce.png">

After:

<img width="822" alt="Screenshot 2021-06-05 at 11 11 40" src="https://user-images.githubusercontent.com/1062408/120886559-e6ccc580-c5ee-11eb-9492-b3ecc48500f4.png">
