### PR TITLE
(docs) URLs with trailing slashes

### DIFF
--- a/docs/public/components/doc-structure.js
+++ b/docs/public/components/doc-structure.js
@@ -4,7 +4,7 @@ export { content };
 const pages = new Map(
 	content.map((item, index) => {
 		if ('heading' in item) return ['', -1];
-		item.slug = `/docs/${item.name}`.replace(/\/index$/g, '');
+		item.slug = `/docs/${item.name.replace(/^index$/, '')}`;
 		return [item.name, index];
 	})
 );


### PR DESCRIPTION
It looks like Netlify automatically redirects to URLs with trailing slashes (go to `wmr.dev/docs`, then reload). I'm not sure if there's a way to turn that off on the Netlify side? If not, we can just generate them with trailing slashes to match.