### PR TITLE
Fix swapped usage of `options.cwd` vs `options.root`

### DIFF
--- a/.changeset/good-apricots-hide.md
+++ b/.changeset/good-apricots-hide.md
@@ -1,0 +1,5 @@
+---
+'@wmrjs/directory-import': minor
+---
+
+Update for WMR `3.x` which corrects the swapped usage of `options.cwd` vs `options.root`.

--- a/.changeset/nine-emus-joke.md
+++ b/.changeset/nine-emus-joke.md
@@ -1,0 +1,11 @@
+---
+'wmr': major
+---
+
+Fix swapped usage of `cwd` vs `root`. Now, `cwd` always refers to the current working directory and `root` the web root to serve from (= usually cwd+/public).
+
+This change was done to reduce the amount of extra knowledge to be aware of when using WMR. It was a frequent source of confusion.
+
+#### Migration guide:
+
+If you used `options.cwd` or `options.root` in one of your plugins you need to swap them.

--- a/docs/public/content/docs/configuration.md
+++ b/docs/public/content/docs/configuration.md
@@ -92,16 +92,16 @@ The mode WMR was started in.
 ### cwd
 
 - Type: `string`
-- Default: `process.cwd()/public/`
+- Default: `process.cwd()`
 
-The main directory to serve files from.
+The path to where WMR was launched from. Used to look up `package.json`.
 
 ### root
 
 - Type: `string`
-- Default: `process.cwd()`
+- Default: `process.cwd()/public`
 
-The path to where WMR was launched from. Used to look up `package.json`.
+The main directory to serve files from
 
 ### out
 

--- a/packages/directory-plugin/src/index.js
+++ b/packages/directory-plugin/src/index.js
@@ -3,7 +3,7 @@ import path from 'path';
 
 /**
  * @param {import("wmr").Options} options
- * @param {string} options.cwd
+ * @param {string} options.root
  * @returns {import('rollup').Plugin}
  */
 function directoryPlugin(options) {
@@ -26,7 +26,7 @@ function directoryPlugin(options) {
 			id = id.slice(INTERNAL.length);
 			let dir = id.split(path.posix.sep).join(path.sep);
 			if (!path.isAbsolute(dir)) {
-				dir = path.join(options.cwd, dir);
+				dir = path.join(options.root, dir);
 			}
 
 			const stats = await fs.stat(dir);

--- a/packages/wmr/src/build.js
+++ b/packages/wmr/src/build.js
@@ -25,7 +25,7 @@ export default async function build(options) {
 
 	const bundleOutput = await bundleProd(options);
 
-	const stats = bundleStats(bundleOutput, path.relative(options.root, options.out));
+	const stats = bundleStats(bundleOutput, path.relative(options.cwd, options.out));
 	process.stdout.write(kl.bold(`\nWrote ${stats.totalText} to disk:`) + stats.assetsText + '\n');
 
 	if (!options.prerender) return;

--- a/packages/wmr/src/bundler.js
+++ b/packages/wmr/src/bundler.js
@@ -9,16 +9,16 @@ const pathToPosix = p => p.split(sep).join(posix.sep);
 
 /** @param {import('wmr').BuildOptions} options */
 export async function bundleProd(options) {
-	let { cwd, root, out, sourcemap, profile, minify, npmChunks = false, output } = options;
+	let { root, cwd, out, sourcemap, profile, minify, npmChunks = false, output } = options;
 
 	// note: we intentionally pass these to Rollup as posix paths
 	const ignore = /^\.\/(node_modules|dist|build)\//;
 	/** @type {string[]} */ const input = [];
 
-	await totalist(cwd, (rel, abs) => {
+	await totalist(root, (rel, abs) => {
 		if (ignore.test(abs)) return;
 		if (!/\.html?/.test(rel)) return;
-		input.push('./' + pathToPosix(relative(root, abs)));
+		input.push('./' + pathToPosix(relative(cwd, abs)));
 	});
 
 	const bundle = await rollup.rollup({
@@ -46,7 +46,7 @@ export async function bundleProd(options) {
 		plugins: [minify && terser({ compress: true, sourcemap })],
 		sourcemap,
 		sourcemapPathTransform(p, mapPath) {
-			let url = pathToPosix(relative(cwd, resolve(dirname(mapPath), p)));
+			let url = pathToPosix(relative(root, resolve(dirname(mapPath), p)));
 			// strip leading relative path
 			url = url.replace(/^\.\//g, '');
 			// replace internal npm prefix

--- a/packages/wmr/src/lib/compile-single-module.js
+++ b/packages/wmr/src/lib/compile-single-module.js
@@ -23,14 +23,13 @@ let cache;
 /**
  * @param {string} input
  * @param {object} options
- * @param {string} options.cwd
  * @param {string} options.out
  * @param {boolean} [options.hmr]
  * @param {boolean} [options.rewriteNodeImports]
  * @param {import('rollup').ModuleFormat} [options.format]
  */
 export const compileSingleModule = withCache(
-	async (input, { cwd, out, hmr = true, rewriteNodeImports = true, format = 'es' }) => {
+	async (input, { out, hmr = true, rewriteNodeImports = true, format = 'es' }) => {
 		// The TS config file should be the only one that passes through here
 		const isConfigFile = input.endsWith('wmr.config.ts');
 		input = input.replace(/\.css\.js$/, '.css');
@@ -64,8 +63,6 @@ export const compileSingleModule = withCache(
 					sourcemap: false,
 					production: false
 				}),
-				// localNpmPlugin(),
-				// wmrStylesPlugin({ cwd }),
 				hmr && wmrPlugin(),
 				htmPlugin()
 			].filter(Boolean)

--- a/packages/wmr/src/lib/plugins.js
+++ b/packages/wmr/src/lib/plugins.js
@@ -27,7 +27,7 @@ import { defaultLoaders } from './default-loaders.js';
  * @returns {import("wmr").Plugin[]}
  */
 export function getPlugins(options) {
-	const { plugins, cwd, publicPath, alias, root, env, minify, mode, sourcemap, features, visualize } = options;
+	const { plugins, publicPath, alias, root, env, minify, mode, sourcemap, features, visualize } = options;
 
 	// Plugins are pre-sorted
 	let split = plugins.findIndex(p => p.enforce === 'post');
@@ -37,13 +37,13 @@ export function getPlugins(options) {
 
 	return [
 		...plugins.slice(0, split),
-		production && htmlEntriesPlugin({ cwd, publicPath }),
+		production && htmlEntriesPlugin({ root, publicPath }),
 		externalUrlsPlugin(),
 		nodeBuiltinsPlugin({ production }),
-		urlPlugin({ inline: !production, cwd, alias }),
-		jsonPlugin({ cwd }),
-		bundlePlugin({ inline: !production, cwd }),
-		aliasPlugin({ alias, cwd: root }),
+		urlPlugin({ inline: !production, root, alias }),
+		jsonPlugin({ root }),
+		bundlePlugin({ inline: !production, cwd: root }),
+		aliasPlugin({ alias }),
 		sucrasePlugin({
 			typescript: true,
 			sourcemap,
@@ -56,7 +56,7 @@ export function getPlugins(options) {
 			}),
 		production && publicPathPlugin({ publicPath }),
 		sassPlugin({ production }),
-		production && wmrStylesPlugin({ hot: false, cwd, production, alias }),
+		production && wmrStylesPlugin({ hot: false, root, production, alias }),
 		processGlobalPlugin({
 			env,
 			NODE_ENV: production ? 'production' : 'development'
@@ -80,7 +80,7 @@ export function getPlugins(options) {
 
 		production && optimizeGraphPlugin({ publicPath }),
 		minify && minifyCssPlugin({ sourcemap }),
-		production && copyAssetsPlugin({ cwd }),
+		production && copyAssetsPlugin({ root }),
 		production && visualize && visualizer({ open: true, gzipSize: true, brotliSize: true })
 	].filter(Boolean);
 }

--- a/packages/wmr/src/plugins/html-entries-plugin.js
+++ b/packages/wmr/src/plugins/html-entries-plugin.js
@@ -22,13 +22,11 @@ const toSystemPath = p => p.split(posix.sep).join(sep);
  * Notably, <scripts> become *user-defined entries*, so they correctly use `output.entryFileNames`.
  *
  * @param {object} options
- * @param {string} [options.cwd]
- * @param {string} [options.publicDir]
+ * @param {string} options.root
  * @param {string} [options.publicPath] Prepend to generated filenames
  * @returns {import('rollup').Plugin}
  */
-export default function htmlEntriesPlugin({ cwd, publicDir, publicPath } = {}) {
-	const root = publicDir || cwd || '.';
+export default function htmlEntriesPlugin({ root, publicPath }) {
 	const ENTRIES = [];
 	const META = new Map();
 
@@ -150,7 +148,7 @@ export default function htmlEntriesPlugin({ cwd, publicDir, publicPath } = {}) {
 					this.error(
 						`\n${bgRed(white(bold(`ERROR`)))} File not found: ${cyan(script)}` +
 							`\n> ${white(
-								`Is the extension correct? ${dim('<script src="')}${magenta(relative(cwd, script))}${dim('">')} ?`
+								`Is the extension correct? ${dim('<script src="')}${magenta(relative(root, script))}${dim('">')} ?`
 							)}\n`
 					);
 				}

--- a/packages/wmr/src/plugins/json-plugin.js
+++ b/packages/wmr/src/plugins/json-plugin.js
@@ -10,10 +10,10 @@ import { promises as fs } from 'fs';
  *   import foo from 'json:./foo.json';
  *
  * @param {object} options
- * @param {string} options.cwd
+ * @param {string} options.root
  * @returns {import('rollup').Plugin}
  */
-export default function jsonPlugin({ cwd }) {
+export default function jsonPlugin({ root }) {
 	const IMPORT_PREFIX = 'json:';
 	const INTERNAL_PREFIX = '\0json:';
 
@@ -37,9 +37,9 @@ export default function jsonPlugin({ cwd }) {
 
 			// TODO: Add a global helper function to normalize paths
 			// and check that we're allowed to load a file.
-			const file = path.resolve(cwd, id);
-			if (!file.startsWith(cwd)) {
-				throw new Error(`JSON file must be placed inside ${cwd}`);
+			const file = path.resolve(root, id);
+			if (!file.startsWith(root)) {
+				throw new Error(`JSON file must be placed inside ${root}`);
 			}
 
 			return await fs.readFile(file, 'utf-8');

--- a/packages/wmr/src/plugins/url-plugin.js
+++ b/packages/wmr/src/plugins/url-plugin.js
@@ -11,11 +11,11 @@ const escapeUrl = url => url.replace(/#/g, '%23').replace(/'/g, "\\'").replace(/
 /**
  * @param {object} options
  * @param {object} [options.inline = false] Emit a Data URL module exporting the URL string.
- * @param {object} [options.cwd] Used to resolve the URL when `inline` is `true`.
+ * @param {object} [options.root] Used to resolve the URL when `inline` is `true`.
  * @param {Record<string, string>} options.alias
  * @returns {import('rollup').Plugin}
  */
-export default function urlPlugin({ inline, cwd, alias }) {
+export default function urlPlugin({ inline, root, alias }) {
 	const PREFIX = 'url:';
 	const INTERNAL_PREFIX = '\0url:';
 
@@ -34,7 +34,7 @@ export default function urlPlugin({ inline, cwd, alias }) {
 			// In dev mode, we turn the import into an inline module that avoids a network request:
 			if (inline) {
 				const aliased = matchAlias(alias, resolved.id);
-				const url = (aliased || '/' + relative(cwd, resolved.id)) + '?asset';
+				const url = (aliased || '/' + relative(root, resolved.id)) + '?asset';
 				log(`${kl.green('inline')} ${kl.dim(url)} <- ${kl.dim(resolved.id)}`);
 				return {
 					id: escapeUrl(`data:text/javascript,export default${JSON.stringify(url)}`),

--- a/packages/wmr/src/plugins/wmr/styles/styles-plugin.js
+++ b/packages/wmr/src/plugins/wmr/styles/styles-plugin.js
@@ -12,14 +12,14 @@ const RESERVED_WORDS = /^(abstract|async|boolean|break|byte|case|catch|char|clas
 /**
  * Implements hot-reloading for stylesheets imported by JS.
  * @param {object} options
- * @param {string} options.cwd Manually specify the cwd from which to resolve filenames (important for calculating hashes!)
+ * @param {string} options.root Manually specify the cwd from which to resolve filenames (important for calculating hashes!)
  * @param {boolean} [options.hot] Indicates the plugin should inject a HMR-runtime
  * @param {boolean} [options.fullPath] Preserve the full original path when producing CSS assets
  * @param {boolean} [options.production]
  * @param {Record<string, string>} options.alias
  * @returns {import('rollup').Plugin}
  */
-export default function wmrStylesPlugin({ cwd, hot, fullPath, production, alias }) {
+export default function wmrStylesPlugin({ root, hot, fullPath, production, alias }) {
 	let assetId = 0;
 	const assetMap = new Map();
 
@@ -31,7 +31,7 @@ export default function wmrStylesPlugin({ cwd, hot, fullPath, production, alias 
 
 			let idRelative = id;
 			let aliased = matchAlias(alias, id);
-			idRelative = aliased ? aliased.slice('/@alias/'.length) : relative(cwd, id);
+			idRelative = aliased ? aliased.slice('/@alias/'.length) : relative(root, id);
 
 			const mappings = [];
 			if (/\.module\.(css|s[ac]ss)$/.test(id)) {
@@ -57,7 +57,7 @@ export default function wmrStylesPlugin({ cwd, hot, fullPath, production, alias 
 						if (spec.indexOf(':') === -1) {
 							const absolute = resolve(dirname(idRelative), spec.split(posix.sep).join(sep));
 
-							if (!absolute.startsWith(cwd)) return;
+							if (!absolute.startsWith(root)) return;
 
 							const ref = `__WMR_ASSET_ID_${assetId++}`;
 							assetMap.set(ref, {

--- a/packages/wmr/src/server.js
+++ b/packages/wmr/src/server.js
@@ -30,9 +30,9 @@ import { hasDebugFlag } from './lib/output-utils.js';
  */
 export default async function server({ cwd, root, overlayDir, middleware, http2, compress = true, optimize, alias }) {
 	try {
-		await fs.access(resolve(cwd, 'index.html'));
+		await fs.access(resolve(root, 'index.html'));
 	} catch (e) {
-		process.stderr.write(kl.yellow(`Warning: missing "index.html" file ${kl.dim(`(in ${cwd})`)}`) + '\n');
+		process.stderr.write(kl.yellow(`Warning: missing "index.html" file ${kl.dim(`(in ${root})`)}`) + '\n');
 	}
 
 	/** @type {CustomServer} */
@@ -67,7 +67,7 @@ export default async function server({ cwd, root, overlayDir, middleware, http2,
 			// We can log the fully detailed error to the CLI
 			const displayPath = fullPath.startsWith('/@')
 				? fullPath
-				: './' + join(relative(root, cwd), fullPath.replace(/^\//, ''));
+				: './' + join(relative(cwd, root), fullPath.replace(/^\//, ''));
 
 			const codeFrame = err.codeFrame ? `\n${err.codeFrame}` : '';
 			const prettyStack = errorstacks
@@ -104,19 +104,19 @@ export default async function server({ cwd, root, overlayDir, middleware, http2,
 		app.use(compression({ threshold, level: 4 }));
 	}
 
-	app.use('/@npm', npmMiddleware({ alias, optimize, cwd: root }));
+	app.use('/@npm', npmMiddleware({ alias, optimize, cwd }));
 
 	if (middleware) {
 		app.use(...middleware);
 	}
 
 	if (overlayDir) {
-		app.use(sirv(resolve(cwd || '', overlayDir), { dev: true }));
+		app.use(sirv(resolve(root || '', overlayDir), { dev: true }));
 	}
 
 	// SPA nav fallback
 	app.use(
-		sirv(cwd || '', {
+		sirv(root || '', {
 			ignores: ['@npm'],
 			single: true,
 			etag: true,

--- a/packages/wmr/src/start.js
+++ b/packages/wmr/src/start.js
@@ -49,7 +49,7 @@ export default async function start(options = {}) {
 	} else {
 		const logWatcher = debug('wmr:watcher');
 		const watcher = watch(configWatchFiles, {
-			cwd: cloned.root,
+			cwd: cloned.cwd,
 			disableGlobbing: true
 		});
 		watcher.on('ready', () => logWatcher(' watching for config changes'));
@@ -149,7 +149,7 @@ async function bootServer(options, configWatchFiles) {
 	};
 }
 
-const injectWmrMiddleware = ({ cwd }) => {
+const injectWmrMiddleware = ({ root }) => {
 	return async (req, res, next) => {
 		// If we haven't intercepted the request it's safe to assume we need to inject wmr.
 		const path = posix.normalize(req.path);
@@ -159,7 +159,7 @@ const injectWmrMiddleware = ({ cwd }) => {
 
 		try {
 			const start = Date.now();
-			const index = resolve(cwd, 'index.html');
+			const index = resolve(root, 'index.html');
 			const html = await fs.readFile(index, 'utf-8');
 			const result = await injectWmr(html);
 			const time = Date.now() - start;

--- a/packages/wmr/test/boot.test.js
+++ b/packages/wmr/test/boot.test.js
@@ -1,6 +1,15 @@
 import path from 'path';
 import { promises as fs } from 'fs';
-import { setupTest, teardown, runWmr, loadFixture, waitForMessage, getOutput, runWmrFast } from './test-helpers.js';
+import {
+	setupTest,
+	teardown,
+	runWmr,
+	loadFixture,
+	waitForMessage,
+	getOutput,
+	runWmrFast,
+	withLog
+} from './test-helpers.js';
 
 jest.setTimeout(30000);
 
@@ -44,14 +53,16 @@ describe('boot', () => {
 		await loadFixture('simple', env);
 		instance = await runWmrFast(env.tmp.path, 'build');
 
-		await waitForMessage(instance.output, /Wrote/);
+		await withLog(instance.output, async () => {
+			await waitForMessage(instance.output, /Wrote/);
 
-		const files = (await fs.readdir(env.tmp.path)).filter(
-			file => !file.startsWith('.env') && !file.includes('node_modules')
-		);
-		expect(files).toEqual(['dist', 'public']);
+			const files = (await fs.readdir(env.tmp.path)).filter(
+				file => !file.startsWith('.env') && !file.includes('node_modules')
+			);
+			expect(files).toEqual(['dist', 'public']);
 
-		const dist = await fs.readdir(path.join(env.tmp.path, 'dist'));
-		expect(dist).toContainEqual(expect.stringMatching(/^index\.[a-z0-9]+\.js$/));
+			const dist = await fs.readdir(path.join(env.tmp.path, 'dist'));
+			expect(dist).toContainEqual(expect.stringMatching(/^index\.[a-z0-9]+\.js$/));
+		});
 	});
 });

--- a/packages/wmr/test/environment.test.js
+++ b/packages/wmr/test/environment.test.js
@@ -1,5 +1,5 @@
 import { parseEnvFile } from '../src/lib/environment.js';
-import { setupTest, teardown, loadFixture, runWmrFast, getOutput } from './test-helpers.js';
+import { setupTest, teardown, loadFixture, runWmrFast, getOutput, withLog } from './test-helpers.js';
 
 describe('.env files', () => {
 	describe('parseEnvFiles', () => {
@@ -51,11 +51,13 @@ describe('.env files', () => {
 		it('should load env files into process.env', async () => {
 			await loadFixture('env', env);
 			instance = await runWmrFast(env.tmp.path);
-			const values = { FOO: 'bar', OVERRIDE: '11', EMPTY: '', FOO_LOCAL: 'bar', NODE_ENV: 'development' };
-			const expected = Object.keys(values)
-				.map(key => `${key}=${JSON.stringify(values[key])}`)
-				.join(', ');
-			expect(await getOutput(env, instance)).toContain(expected);
+			await withLog(instance.output, async () => {
+				const values = { FOO: 'bar', OVERRIDE: '11', EMPTY: '', FOO_LOCAL: 'bar', NODE_ENV: 'development' };
+				const expected = Object.keys(values)
+					.map(key => `${key}=${JSON.stringify(values[key])}`)
+					.join(', ');
+				expect(await getOutput(env, instance)).toContain(expected);
+			});
 		});
 	});
 });

--- a/packages/wmr/test/fixtures/plugin-hooks/public/index.html
+++ b/packages/wmr/test/fixtures/plugin-hooks/public/index.html
@@ -1,0 +1,1 @@
+<p>Nothing to see here!</p>

--- a/packages/wmr/test/fixtures/plugin-hooks/wmr.config.mjs
+++ b/packages/wmr/test/fixtures/plugin-hooks/wmr.config.mjs
@@ -1,0 +1,13 @@
+export default function foo() {
+	return [
+		{
+			name: 'plugin-a',
+			async config(config) {
+				console.log(`plugin-a: config() cwd: ${config.cwd}, root: ${config.root} }`);
+			},
+			configResolved(config) {
+				console.log(`plugin-a: configResolved() { cwd: ${config.cwd}, root: ${config.root} }`);
+			}
+		}
+	];
+}

--- a/packages/wmr/test/plugins/plugins.test.js
+++ b/packages/wmr/test/plugins/plugins.test.js
@@ -1,0 +1,40 @@
+import { loadFixture, runWmrFast, setupTest, teardown, waitForMessage, withLog } from '../test-helpers.js';
+
+jest.setTimeout(30000);
+
+describe('config', () => {
+	/** @type {TestEnv} */
+	let env;
+	/** @type {WmrInstance} */
+	let instance;
+
+	beforeEach(async () => {
+		env = await setupTest();
+	});
+
+	afterEach(async () => {
+		await teardown(env);
+		instance.close();
+	});
+
+	/* eslint-disable jest/expect-expect */
+	describe('plugins', () => {
+		it('should call custom hooks in right order', async () => {
+			await loadFixture('plugin-hooks', env);
+			instance = await runWmrFast(env.tmp.path);
+			await instance.address;
+			await withLog(instance.output, async () => {
+				await waitForMessage(instance.output, /plugin-a/);
+
+				// Check that config() was called before configResolved()
+				const configHook = instance.output.findIndex(line => /plugin-a: config\(\)/.test(line));
+				const configResolvedHook = instance.output.findIndex(line => /plugin-a: configResolved\(\)/.test(line));
+				expect(configHook < configResolvedHook).toEqual(true);
+
+				// Check that both "cwd" and "root" are correct
+				expect(instance.output[configHook]).toMatch(/cwd:.*, root:.*\/public/);
+				expect(instance.output[configResolvedHook]).toMatch(/cwd:.*, root:.*\/public/);
+			});
+		});
+	});
+});


### PR DESCRIPTION
This PR corrects the swapped usage of `options.cwd` vs `options.root`. The former is now always equal to the current working directory and `options.root` points to the absolute public dir (=usually `<cwd>/public`).

Marking as major, because users might have worked around the swapped usage in custom plugins and doing this in a non-major release would break their config.

For the directory plugin a major release is not necessary, because npm treats minor versions below `< 1.0.0` as major and won't update to that automatically.

Fixes #142