### PR TITLE
Rewrite styles pipeline to get rid of transform abstraction for CSS

### DIFF
--- a/.changeset/shiny-adults-brake.md
+++ b/.changeset/shiny-adults-brake.md
@@ -1,0 +1,11 @@
+---
+'wmr': major
+---
+
+Completely rewrite our stylesheet pipeline. All CSS files can now be intercepted from plugins allowing us to leverage the same pipeline that we use for production during development.
+
+- Fixes `.scss/.sass` not compiled on watch
+- Fixes nested `.scss/.sass` files not compiled with sass
+- Fixes `.scss/.sass` files not compiled when directly referenced in HTML
+- Fixes asset caching overwriting each others entries
+- Adds groundwork for intercepting urls inside css for aliasing or resolving from `node_modules`

--- a/packages/wmr/package.json
+++ b/packages/wmr/package.json
@@ -74,6 +74,7 @@
 		"rollup-plugin-preserve-shebang": "^1.0.1",
 		"rollup-plugin-visualizer": "^4.2.2",
 		"sade": "^1.7.3",
+		"sass": "^1.34.1",
 		"semver": "^7.3.2",
 		"simple-code-frame": "^1.1.1",
 		"sirv": "^1.0.6",

--- a/packages/wmr/src/lib/plugins.js
+++ b/packages/wmr/src/lib/plugins.js
@@ -56,7 +56,7 @@ export function getPlugins(options) {
 			}),
 		production && publicPathPlugin({ publicPath }),
 		sassPlugin({ production }),
-		production && wmrStylesPlugin({ hot: false, root, production, alias }),
+		wmrStylesPlugin({ hot: !production, root, production, alias }),
 		processGlobalPlugin({
 			env,
 			NODE_ENV: production ? 'production' : 'development'

--- a/packages/wmr/src/lib/rollup-plugin-container.js
+++ b/packages/wmr/src/lib/rollup-plugin-container.js
@@ -193,14 +193,23 @@ export function createPluginContainer(plugins, opts = {}) {
 			);
 		},
 
-		/** @param {string} id */
+		/**
+		 * @param {string} id
+		 * @returns {string[]} WMR specific
+		 */
 		watchChange(id) {
+			const pending = [];
 			if (watchFiles.has(id)) {
 				for (plugin of plugins) {
 					if (!plugin.watchChange) continue;
-					plugin.watchChange.call(ctx, id);
+					// Note return value is WMR specific
+					const res = plugin.watchChange.call(ctx, id);
+					if (Array.isArray(res)) {
+						pending.push(...res);
+					}
 				}
 			}
+			return pending;
 		},
 
 		/** @param {string} property */

--- a/packages/wmr/src/plugins/sass-plugin.js
+++ b/packages/wmr/src/plugins/sass-plugin.js
@@ -24,10 +24,9 @@ async function renderSass(opts) {
 		}
 
 		if (!sass) {
-			console.warn(
+			throw new Error(
 				`Please install a sass implementation to use sass/scss:\n    npm i -D sass\n  or:\n    npm i -D node-sass`
 			);
-			sass = ({ data }) => ({ css: data, map: null });
 		}
 	}
 

--- a/packages/wmr/src/plugins/sass-plugin.js
+++ b/packages/wmr/src/plugins/sass-plugin.js
@@ -62,7 +62,7 @@ export default function sassPlugin({ production = false, sourcemap = false } = {
 
 			return {
 				code: result.css,
-				map: (sourcemap && result.map) || null
+				map: result.map || null
 			};
 		}
 	};

--- a/packages/wmr/src/plugins/sass-plugin.js
+++ b/packages/wmr/src/plugins/sass-plugin.js
@@ -15,10 +15,11 @@ async function renderSass(opts) {
 	if (!sass) {
 		for (const loc of ['sass', 'node-sass']) {
 			try {
+				log(kl.dim(`Attempting to load compiler from `) + kl.cyan(loc));
 				const sassLib = await import(loc);
-				log(`-> Using sass from ${kl.green(loc)}`);
+				log(kl.dim(`Loaded compiler from `) + kl.green(loc));
 
-				sass = promisify(sassLib.render.bind(sass));
+				sass = promisify((sassLib.default || sassLib).render.bind(sass));
 				break;
 			} catch (e) {}
 		}

--- a/packages/wmr/src/plugins/sass-plugin.js
+++ b/packages/wmr/src/plugins/sass-plugin.js
@@ -75,7 +75,8 @@ export default function sassPlugin({ production = false, sourcemap = false } = {
 				if (!fileToBundles.has(file)) {
 					fileToBundles.set(file, new Set());
 				}
-				fileToBundles.get(file)?.add(id);
+				// @ts-ignore
+				fileToBundles.get(file).add(id);
 			}
 
 			return {

--- a/packages/wmr/src/plugins/wmr/client.js
+++ b/packages/wmr/src/plugins/wmr/client.js
@@ -54,8 +54,8 @@ function handleMessage(e) {
 				url = resolve(url);
 				if (!mods.get(url)) {
 					if (/\.(css|s[ac]ss)$/.test(url)) {
-						if (mods.has(url + '.js')) {
-							url += '.js';
+						if (mods.has(url + '?module')) {
+							url += '?module';
 						} else {
 							updateStyleSheet(url);
 							return;

--- a/packages/wmr/src/plugins/wmr/client.js
+++ b/packages/wmr/src/plugins/wmr/client.js
@@ -140,7 +140,7 @@ function update(url, date) {
 	const mod = getMod(url);
 	const dispose = Array.from(mod.dispose);
 	const accept = Array.from(mod.accept);
-	const newUrl = url + '?t=' + date;
+	const newUrl = url + (/\?/.test(url) ? '&' : '?') + 't=' + date;
 	const p = mod.import ? mod.import(newUrl) : import(newUrl);
 
 	return p
@@ -193,7 +193,7 @@ export function style(filename, id) {
 	id = resolve(id || filename);
 	let node = styles.get(id);
 	if (node) {
-		node.href = filename + '?t=' + Date.now();
+		node.href = filename + (/\?/.test(filename) ? '&' : '?') + 't=' + Date.now();
 	} else {
 		const node = document.createElement('link');
 		node.rel = 'stylesheet';

--- a/packages/wmr/src/wmr-middleware.js
+++ b/packages/wmr/src/wmr-middleware.js
@@ -52,7 +52,7 @@ export default function wmrMiddleware(options) {
 			// chunkFileNames: '[name][extname]',
 			// Use a hash to prevent collisions between assets with the
 			// same basename.
-			assetFileNames: '[name]-[hash][extname]?asset',
+			assetFileNames: '[name][extname]?asset',
 			dir: out
 		}
 	});

--- a/packages/wmr/src/wmr-middleware.js
+++ b/packages/wmr/src/wmr-middleware.js
@@ -1,4 +1,4 @@
-import path, { resolve, dirname, relative, sep, posix, isAbsolute, normalize, basename } from 'path';
+import { resolve, dirname, relative, sep, posix, isAbsolute, normalize, basename } from 'path';
 import { promises as fs, createReadStream } from 'fs';
 import * as kl from 'kolorist';
 import { getWmrClient } from './plugins/wmr/plugin.js';
@@ -39,10 +39,10 @@ export default function wmrMiddleware(options) {
 		writeFile: (filename, source) => {
 			// Remove .cache folder from filename if present. The cache
 			// works with relative keys only.
-			if (path.isAbsolute(filename)) {
-				const relative = path.relative(out, filename);
-				if (!relative.startsWith('..')) {
-					filename = relative;
+			if (isAbsolute(filename)) {
+				const relativeFile = relative(out, filename);
+				if (!relativeFile.startsWith('..')) {
+					filename = relativeFile;
 				}
 			}
 			writeCacheFile(out, filename, source);

--- a/packages/wmr/test/fixtures.test.js
+++ b/packages/wmr/test/fixtures.test.js
@@ -91,8 +91,7 @@ describe('fixtures', () => {
 		instance = await runWmrFast(env.tmp.path);
 		const text = await getOutput(env, instance);
 
-		// TODO: Investigate hashed aliasing vs aliases
-		expect(text).toMatch(/my-url: \/foo-.+\.svg\?asset/);
+		expect(text).toMatch(/my-url: \/foo\.svg\?asset/);
 		expect(text).toMatch(/url: \/foo\.svg\?asset/);
 		expect(text).toMatch(/fallback: \/foo\.svg\?asset/);
 	});
@@ -379,7 +378,7 @@ describe('fixtures', () => {
 			await loadFixture('css-imports', env);
 			instance = await runWmrFast(env.tmp.path);
 			await getOutput(env, instance);
-			expect(await env.page.$eval('body', el => getComputedStyle(el).backgroundImage)).toMatch(/img-.+\.jpg/);
+			expect(await env.page.$eval('body', el => getComputedStyle(el).backgroundImage)).toMatch(/img\.jpg/);
 		});
 
 		it('should warn on CSS modules with reserved class names', async () => {

--- a/packages/wmr/test/fixtures.test.js
+++ b/packages/wmr/test/fixtures.test.js
@@ -91,7 +91,8 @@ describe('fixtures', () => {
 		instance = await runWmrFast(env.tmp.path);
 		const text = await getOutput(env, instance);
 
-		expect(text).toMatch(/my-url: \/foo\.svg\?asset/);
+		// TODO: Investigate hashed aliasing vs aliases
+		expect(text).toMatch(/my-url: \/foo-.+\.svg\?asset/);
 		expect(text).toMatch(/url: \/foo\.svg\?asset/);
 		expect(text).toMatch(/fallback: \/foo\.svg\?asset/);
 	});

--- a/packages/wmr/test/fixtures.test.js
+++ b/packages/wmr/test/fixtures.test.js
@@ -379,7 +379,7 @@ describe('fixtures', () => {
 			await loadFixture('css-imports', env);
 			instance = await runWmrFast(env.tmp.path);
 			await getOutput(env, instance);
-			expect(await env.page.$eval('body', el => getComputedStyle(el).background)).toMatch(/img\.jpg/);
+			expect(await env.page.$eval('body', el => getComputedStyle(el).backgroundImage)).toMatch(/img-.+\.jpg/);
 		});
 
 		it('should warn on CSS modules with reserved class names', async () => {

--- a/packages/wmr/test/fixtures.test.js
+++ b/packages/wmr/test/fixtures.test.js
@@ -398,6 +398,28 @@ describe('fixtures', () => {
 		});
 	});
 
+	describe('Sass', () => {
+		it('should transform sass files', async () => {
+			await loadFixture('css-sass', env);
+			instance = await runWmrFast(env.tmp.path);
+			await getOutput(env, instance);
+
+			await withLog(instance.output, async () => {
+				expect(await env.page.$eval('h1', el => getComputedStyle(el).color)).toMatch(/rgb\(255, 0, 0\)/);
+			});
+		});
+
+		it('should transform sass modules', async () => {
+			await loadFixture('css-sass-module', env);
+			instance = await runWmrFast(env.tmp.path);
+			await getOutput(env, instance);
+
+			await withLog(instance.output, async () => {
+				expect(await env.page.$eval('h1', el => getComputedStyle(el).color)).toMatch(/rgb\(255, 0, 0\)/);
+			});
+		});
+	});
+
 	describe('hmr', () => {
 		const timeout = n => new Promise(r => setTimeout(r, n));
 
@@ -431,10 +453,10 @@ describe('fixtures', () => {
 				content.replace('<p class="home">Home</p>', '<p class="home">Away</p>')
 			);
 
-			await timeout(1000);
-
-			text = home ? await home.evaluate(el => el.textContent) : null;
-			expect(text).toEqual('Away');
+			await waitForPass(async () => {
+				text = home ? await home.evaluate(el => el.textContent) : null;
+				expect(text).toEqual('Away');
+			});
 		});
 
 		it('should bubble up updates in non-accepted files', async () => {
@@ -531,9 +553,9 @@ describe('fixtures', () => {
 
 			await updateFile(env.tmp.path, 'index.css', content => content.replace('color: #333;', 'color: #000;'));
 
-			await timeout(1000);
-
-			expect(await page.$eval('body', e => getComputedStyle(e).color)).toBe('rgb(0, 0, 0)');
+			await waitForPass(async () => {
+				expect(await page.$eval('body', e => getComputedStyle(e).color)).toBe('rgb(0, 0, 0)');
+			});
 		});
 
 		it('should hot reload a module css-file', async () => {
@@ -545,9 +567,9 @@ describe('fixtures', () => {
 
 			await updateFile(env.tmp.path, 'style.module.css', content => content.replace('color: #333;', 'color: #000;'));
 
-			await timeout(1000);
-
-			expect(await page.$eval('main', e => getComputedStyle(e).color)).toBe('rgb(0, 0, 0)');
+			await waitForPass(async () => {
+				expect(await page.$eval('main', e => getComputedStyle(e).color)).toBe('rgb(0, 0, 0)');
+			});
 		});
 	});
 

--- a/packages/wmr/test/fixtures/css-module/foo.module.css
+++ b/packages/wmr/test/fixtures/css-module/foo.module.css
@@ -1,0 +1,3 @@
+.foo {
+	background: peachpuff;
+}

--- a/packages/wmr/test/fixtures/css-module/index.html
+++ b/packages/wmr/test/fixtures/css-module/index.html
@@ -1,0 +1,2 @@
+<h1 class="foo">foo</h1>
+<script src="./index.js" type="module"></script>

--- a/packages/wmr/test/fixtures/css-module/index.js
+++ b/packages/wmr/test/fixtures/css-module/index.js
@@ -1,0 +1,3 @@
+import styles from './foo.module.css';
+
+document.querySelector('.foo')?.classList.add(styles.foo);

--- a/packages/wmr/test/fixtures/css-sass-module/public/index.html
+++ b/packages/wmr/test/fixtures/css-sass-module/public/index.html
@@ -1,0 +1,2 @@
+<h1>Sass</h1>
+<script type="module" src="./index.js"></script>

--- a/packages/wmr/test/fixtures/css-sass-module/public/index.js
+++ b/packages/wmr/test/fixtures/css-sass-module/public/index.js
@@ -1,0 +1,3 @@
+import styles from './style.module.scss';
+
+document.querySelector('h1')?.classList.add(styles.foo);

--- a/packages/wmr/test/fixtures/css-sass-module/public/style.module.scss
+++ b/packages/wmr/test/fixtures/css-sass-module/public/style.module.scss
@@ -1,0 +1,5 @@
+$color: red;
+
+.foo {
+	color: $color;
+}

--- a/packages/wmr/test/fixtures/css-sass/public/index.html
+++ b/packages/wmr/test/fixtures/css-sass/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="utf-8" />
+		<title>sass</title>
+		<link rel="stylesheet" href="style.scss" />
+	</head>
+	<body>
+		<h1>Sass</h1>
+	</body>
+</html>

--- a/packages/wmr/test/fixtures/css-sass/public/style.scss
+++ b/packages/wmr/test/fixtures/css-sass/public/style.scss
@@ -1,0 +1,5 @@
+$color: red;
+
+h1 {
+	color: $color;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2058,7 +2058,7 @@ charenc@0.0.2:
   resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
   integrity sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=
 
-chokidar@^3.2.2, chokidar@^3.4.0:
+"chokidar@>=3.0.0 <4.0.0", chokidar@^3.2.2, chokidar@^3.4.0:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.1.tgz#ee9ce7bbebd2b79f49f304799d5468e31e14e68a"
   integrity sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==
@@ -7905,6 +7905,13 @@ sane@^4.0.3:
     micromatch "^3.1.4"
     minimist "^1.1.1"
     walker "~1.0.5"
+
+sass@^1.34.1:
+  version "1.34.1"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.34.1.tgz#30f45c606c483d47b634f1e7371e13ff773c96ef"
+  integrity sha512-scLA7EIZM+MmYlej6sdVr0HRbZX5caX5ofDT9asWnUJj21oqgsC+1LuNfm0eg+vM0fCTZHhwImTiCU0sx9h9CQ==
+  dependencies:
+    chokidar ">=3.0.0 <4.0.0"
 
 sax@~1.2.4:
   version "1.2.4"


### PR DESCRIPTION
Completely rewrite our stylesheet pipeline. All CSS files can now be intercepted from plugins allowing us to leverage the same pipeline that we use for production during development.

- Fixes `.scss/.sass` not compiled on watch
- Fixes nested `.scss/.sass` files not compiled with sass
- Fixes `.scss/.sass` files not compiled when directly referenced in HTML
- Fixes asset caching overwriting each others entries
- Adds groundwork for intercepting urls inside css for aliasing (#685) or resolving from `node_modules` (didn't want to make this PR even larger, will come in a next PR)

Notes:

- Proxy modules `foo.module.css.js` are now specified by a query param: `foo.module.css?module`.
- Assets now have hashes to avoid collisions in our cache. We had assets that overwrote each others entries

This PR replaces #657 .



 

