### PR TITLE
Sass: Add support for resolving imported paths

### DIFF
--- a/.changeset/seven-moons-fail.md
+++ b/.changeset/seven-moons-fail.md
@@ -1,0 +1,5 @@
+---
+'wmr': minor
+---
+
+Sass: Include imported urls and file path into plugin resolution. This allows sass to load aliased files for example.

--- a/packages/wmr/src/lib/plugins.js
+++ b/packages/wmr/src/lib/plugins.js
@@ -55,7 +55,7 @@ export function getPlugins(options) {
 				exclude: /\/node_modules\//
 			}),
 		production && publicPathPlugin({ publicPath }),
-		sassPlugin({ production }),
+		sassPlugin({ production, sourcemap, root }),
 		wmrStylesPlugin({ hot: !production, root, production, alias }),
 		processGlobalPlugin({
 			env,

--- a/packages/wmr/test/fixtures.test.js
+++ b/packages/wmr/test/fixtures.test.js
@@ -418,6 +418,16 @@ describe('fixtures', () => {
 				expect(await env.page.$eval('h1', el => getComputedStyle(el).color)).toMatch(/rgb\(255, 0, 0\)/);
 			});
 		});
+
+		it('should transform aliased imports modules', async () => {
+			await loadFixture('css-sass-alias', env);
+			instance = await runWmrFast(env.tmp.path);
+			await getOutput(env, instance);
+
+			await withLog(instance.output, async () => {
+				expect(await env.page.$eval('h1', el => getComputedStyle(el).color)).toMatch(/rgb\(255, 0, 0\)/);
+			});
+		});
 	});
 
 	describe('hmr', () => {

--- a/packages/wmr/test/fixtures/css-sass-alias/foo/foo.scss
+++ b/packages/wmr/test/fixtures/css-sass-alias/foo/foo.scss
@@ -1,0 +1,1 @@
+$color: red;

--- a/packages/wmr/test/fixtures/css-sass-alias/public/index.html
+++ b/packages/wmr/test/fixtures/css-sass-alias/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="utf-8" />
+		<title>sass</title>
+		<link rel="stylesheet" href="style.scss" />
+	</head>
+	<body>
+		<h1>Sass</h1>
+	</body>
+</html>

--- a/packages/wmr/test/fixtures/css-sass-alias/public/style.scss
+++ b/packages/wmr/test/fixtures/css-sass-alias/public/style.scss
@@ -1,0 +1,5 @@
+@import '~/foo.scss';
+
+h1 {
+	color: $color;
+}

--- a/packages/wmr/test/fixtures/css-sass-alias/wmr.config.mjs
+++ b/packages/wmr/test/fixtures/css-sass-alias/wmr.config.mjs
@@ -1,0 +1,5 @@
+export default {
+	alias: {
+		'~/*': 'foo'
+	}
+};


### PR DESCRIPTION
This allows sass to load aliased files and anything else plugins might resolve an url to.

Based on #684

Fixes #645, fixes #642 .