### PR TITLE
Fix CLI environment variables overwritten by .env files

### DIFF
--- a/.changeset/old-toys-divide.md
+++ b/.changeset/old-toys-divide.md
@@ -1,0 +1,5 @@
+---
+'wmr': patch
+---
+
+Fix CLI environment variables overwritten by `.env` files

--- a/packages/wmr/src/lib/normalize-options.js
+++ b/packages/wmr/src/lib/normalize-options.js
@@ -42,8 +42,8 @@ export async function normalizeOptions(options, mode, configWatchFiles = []) {
 		configWatchFiles
 	);
 	options.env = {
-		...getWmrEnvVars(),
-		...envFileVars
+		...envFileVars,
+		...getWmrEnvVars()
 	};
 
 	// Output directory is relative to CWD *before* ./public is detected + appended:

--- a/packages/wmr/test/environment.test.js
+++ b/packages/wmr/test/environment.test.js
@@ -59,5 +59,19 @@ describe('.env files', () => {
 				expect(await getOutput(env, instance)).toContain(expected);
 			});
 		});
+
+		it('should give env variables precedence over env files', async () => {
+			await loadFixture('env-precedence', env);
+			instance = await runWmrFast(env.tmp.path, { env: { WMR_FOO: 'it works' } });
+			await getOutput(env, instance);
+
+			await withLog(instance.output, async () => {
+				const foo = await page.$eval('#foo', el => el.textContent);
+				const bar = await page.$eval('#bar', el => el.textContent);
+
+				expect(foo).toEqual('it works');
+				expect(bar).toEqual('it works');
+			});
+		});
 	});
 });

--- a/packages/wmr/test/fixtures/env-precedence/.env
+++ b/packages/wmr/test/fixtures/env-precedence/.env
@@ -1,0 +1,2 @@
+WMR_BAR="it works"
+WMR_FOO="it doesn't work"

--- a/packages/wmr/test/fixtures/env-precedence/index.html
+++ b/packages/wmr/test/fixtures/env-precedence/index.html
@@ -1,0 +1,3 @@
+<p id="foo">it doesn't work</p>
+<p id="bar">it doesn't work</p>
+<script src="./index.js" type="module"></script>

--- a/packages/wmr/test/fixtures/env-precedence/index.js
+++ b/packages/wmr/test/fixtures/env-precedence/index.js
@@ -1,0 +1,2 @@
+document.getElementById('foo').textContent = import.meta.env.WMR_FOO;
+document.getElementById('bar').textContent = import.meta.env.WMR_BAR;

--- a/packages/wmr/test/fixtures/env-precedence/wmr.config.mjs
+++ b/packages/wmr/test/fixtures/env-precedence/wmr.config.mjs
@@ -1,0 +1,9 @@
+const settings = {
+	env: {
+		FOO: 'asdf'
+	}
+};
+// API_URL from `.env` gets overwritten with `undefined`
+export default options => {
+	Object.assign(options.env, settings.env);
+};


### PR DESCRIPTION
Explicit environment variables passed via the CLI should always take precedence over anything else.

```sh
WMR_FOO="foo" wmr start
```