### PR TITLE
Extract CSS tests

### DIFF
--- a/packages/wmr/test/css.test.js
+++ b/packages/wmr/test/css.test.js
@@ -1,0 +1,127 @@
+import {
+	getOutput,
+	loadFixture,
+	runWmrFast,
+	setupTest,
+	teardown,
+	updateFile,
+	waitForPass,
+	withLog
+} from './test-helpers.js';
+import path from 'path';
+
+jest.setTimeout(30000);
+
+describe('CSS', () => {
+	/** @type {TestEnv} */
+	let env;
+	/** @type {WmrInstance} */
+	let instance;
+
+	beforeEach(async () => {
+		env = await setupTest();
+	});
+
+	afterEach(async () => {
+		await teardown(env);
+		instance.close();
+	});
+
+	it('should load referenced files via @import', async () => {
+		await loadFixture('css-imports', env);
+		instance = await runWmrFast(env.tmp.path);
+		await getOutput(env, instance);
+
+		await withLog(instance.output, async () => {
+			expect(await env.page.$eval('h1', el => getComputedStyle(el).color)).toBe('rgb(255, 0, 0)');
+		});
+	});
+
+	it('should load referenced files via url()', async () => {
+		await loadFixture('css-imports', env);
+		instance = await runWmrFast(env.tmp.path);
+		await getOutput(env, instance);
+		expect(await env.page.$eval('body', el => getComputedStyle(el).backgroundImage)).toMatch(/img\.jpg/);
+	});
+
+	describe('CSS Modules', () => {
+		it('should hot reload a module css-file', async () => {
+			await loadFixture('hmr', env);
+			instance = await runWmrFast(env.tmp.path);
+			await getOutput(env, instance);
+
+			expect(await page.$eval('main', e => getComputedStyle(e).color)).toBe('rgb(51, 51, 51)');
+
+			await updateFile(env.tmp.path, 'style.module.css', content => content.replace('color: #333;', 'color: #000;'));
+
+			await waitForPass(async () => {
+				expect(await page.$eval('main', e => getComputedStyle(e).color)).toBe('rgb(0, 0, 0)');
+			});
+		});
+
+		it('should warn on CSS modules with reserved class names', async () => {
+			await loadFixture('css-module-reserved', env);
+			instance = await runWmrFast(env.tmp.path);
+			await getOutput(env, instance);
+
+			await waitForPass(async () => {
+				expect(await env.page.$eval('.foo', el => getComputedStyle(el).backgroundColor)).toBe('rgb(255, 218, 185)');
+				expect(await env.page.$eval('.new', el => getComputedStyle(el).backgroundColor)).toBe('rgb(255, 255, 0)');
+				expect(await env.page.$eval('.debugger', el => getComputedStyle(el).backgroundColor)).toBe('rgb(255, 0, 0)');
+				expect(await env.page.$eval('.const', el => getComputedStyle(el).backgroundColor)).toBe('rgb(255, 218, 185)');
+			});
+
+			expect(instance.output.join('\n')).toMatch(/Cannot use reserved word/);
+		});
+	});
+
+	describe('HMR', () => {
+		it('should hot reload a css-file imported from index.html', async () => {
+			await loadFixture('hmr', env);
+			instance = await runWmrFast(env.tmp.path);
+			await getOutput(env, instance);
+
+			expect(await page.$eval('body', e => getComputedStyle(e).color)).toBe('rgb(51, 51, 51)');
+
+			await updateFile(env.tmp.path, 'index.css', content => content.replace('color: #333;', 'color: #000;'));
+
+			await waitForPass(async () => {
+				expect(await page.$eval('body', e => getComputedStyle(e).color)).toBe('rgb(0, 0, 0)');
+			});
+		});
+
+		it('should hot reload a nested css-file', async () => {
+			await loadFixture('hmr-css', env);
+			instance = await runWmrFast(env.tmp.path);
+			await getOutput(env, instance);
+
+			await withLog(instance.output, async () => {
+				expect(await page.$eval('h1', e => getComputedStyle(e).color)).toBe('rgb(51, 51, 51)');
+
+				await updateFile(env.tmp.path, path.join('public', 'home.css'), content =>
+					content.replace('color: #333;', 'color: red;')
+				);
+
+				await waitForPass(async () => {
+					expect(await page.$eval('h1', e => getComputedStyle(e).color)).toBe('rgb(255, 0, 0)');
+				});
+			});
+		});
+
+		it('should hot reload a nested css-file with no public folder', async () => {
+			await loadFixture('hmr-css-no-public', env);
+			instance = await runWmrFast(env.tmp.path);
+			await getOutput(env, instance);
+
+			await withLog(instance.output, async () => {
+				expect(await page.$eval('h1', e => getComputedStyle(e).color)).toBe('rgb(51, 51, 51)');
+
+				await updateFile(env.tmp.path, 'home.css', content => content.replace('color: #333;', 'color: red;'));
+
+				await waitForPass(async () => {
+					expect(await page.$eval('h1', e => getComputedStyle(e).color)).toBe('rgb(255, 0, 0)');
+				});
+			});
+		});
+	});
+});

--- a/packages/wmr/test/test-helpers.js
+++ b/packages/wmr/test/test-helpers.js
@@ -292,6 +292,19 @@ export async function withLog(haystack, fn) {
 }
 
 /**
+ * Update the contents of a file. Useful for HMR or watch tests
+ * @param {string} tempDir Path to the temporary fixture directory
+ * @param {string} file filename or fiel path
+ * @param {(content: string) => string} replacer callback to replace content
+ * @returns {Promise<void>}
+ */
+export async function updateFile(tempDir, file, replacer) {
+	const compPath = path.join(tempDir, file);
+	const content = await fs.readFile(compPath, 'utf-8');
+	await fs.writeFile(compPath, replacer(content));
+}
+
+/**
  * @param {WmrInstance} instance
  * @param {string} urlPath
  * @returns {Promise<{status?: number, body: string, res: import('http').IncomingMessage }>}


### PR DESCRIPTION
This PR extracts the CSS tests to a separate file. This makes them easier to run separately and the `fixtures.test.js` file has gotten pretty long anyway.

We also benefit from quicker test times as jest parallelizes files.