### PR TITLE
Fix CSS assets sharing same URL

### DIFF
--- a/.changeset/ninety-moles-sparkle.md
+++ b/.changeset/ninety-moles-sparkle.md
@@ -1,0 +1,5 @@
+---
+'wmr': patch
+---
+
+Fix potential issue during development, where different CSS assets would share the same URL

--- a/packages/wmr/src/lib/rollup-plugin-container.js
+++ b/packages/wmr/src/lib/rollup-plugin-container.js
@@ -331,7 +331,7 @@ export function createPluginContainer(plugins, opts = {}) {
 					return result;
 				}
 			}
-			return JSON.stringify('/' + fileName.split(sep).join(posix.sep));
+			return JSON.stringify(posix.normalize('/' + fileName.split(sep).join(posix.sep)));
 		}
 	};
 

--- a/packages/wmr/src/plugins/wmr/styles/styles-plugin.js
+++ b/packages/wmr/src/plugins/wmr/styles/styles-plugin.js
@@ -98,7 +98,13 @@ export default function wmrStylesPlugin({ root, hot, production, alias }) {
 			const ref = this.emitFile({
 				type: 'asset',
 				name: basename(id).replace(/\.s[ac]ss$/, '.css'),
-				fileName: undefined,
+				// Preserve asset path to avoid file clashes:
+				//   foo/styles.module.css
+				//   bar/styles.module.css
+				// Both files above should not overwrite each other.
+				// We don't have that problem in production, because
+				// assets are hashed
+				fileName: !production ? id + '?asset' : undefined,
 				source
 			});
 

--- a/packages/wmr/src/wmr-middleware.js
+++ b/packages/wmr/src/wmr-middleware.js
@@ -637,6 +637,7 @@ export const TRANSFORMS = {
 async function writeCacheFile(rootDir, fileName, data) {
 	if (fileName.includes('\0')) return;
 
+	fileName = normalize(fileName);
 	WRITE_CACHE.set(fileName, data);
 	const filePath = resolve(rootDir, fileName);
 	logCache(`write ${kl.cyan(fileName)} -> ${kl.dim(filePath)}`);

--- a/packages/wmr/test/fixtures/css-module-clash/public/bar/bar.js
+++ b/packages/wmr/test/fixtures/css-module-clash/public/bar/bar.js
@@ -1,0 +1,3 @@
+import styles from './styles.module.css';
+
+document.querySelector('#bar')?.classList.add(styles.bar);

--- a/packages/wmr/test/fixtures/css-module-clash/public/bar/styles.module.css
+++ b/packages/wmr/test/fixtures/css-module-clash/public/bar/styles.module.css
@@ -1,0 +1,3 @@
+.bar {
+	color: red;
+}

--- a/packages/wmr/test/fixtures/css-module-clash/public/foo/foo.js
+++ b/packages/wmr/test/fixtures/css-module-clash/public/foo/foo.js
@@ -1,0 +1,3 @@
+import styles from './styles.module.css';
+
+document.querySelector('#foo')?.classList.add(styles.foo);

--- a/packages/wmr/test/fixtures/css-module-clash/public/foo/styles.module.css
+++ b/packages/wmr/test/fixtures/css-module-clash/public/foo/styles.module.css
@@ -1,0 +1,3 @@
+.foo {
+	color: blue;
+}

--- a/packages/wmr/test/fixtures/css-module-clash/public/index.html
+++ b/packages/wmr/test/fixtures/css-module-clash/public/index.html
@@ -1,0 +1,3 @@
+<h1 id="foo">foo</h1>
+<h2 id="bar">bar</h2>
+<script src="./index.js" type="module"></script>

--- a/packages/wmr/test/fixtures/css-module-clash/public/index.js
+++ b/packages/wmr/test/fixtures/css-module-clash/public/index.js
@@ -1,0 +1,2 @@
+import './foo/foo.js';
+import './bar/bar.js';


### PR DESCRIPTION
Fix potential issue during development, where different CSS assets would share the same URL. This occured whenever multiple CSS files had the same filename.