### PR TITLE
Sass: Fix HMR not working on windows

### DIFF
--- a/.changeset/tiny-pants-cry.md
+++ b/.changeset/tiny-pants-cry.md
@@ -1,0 +1,5 @@
+---
+'wmr': patch
+---
+
+Sass: Fix HMR not working on windows due to `node-sass` returning unix-style paths

--- a/packages/wmr/src/plugins/sass-plugin.js
+++ b/packages/wmr/src/plugins/sass-plugin.js
@@ -117,7 +117,10 @@ export default function sassPlugin({ production, sourcemap, root }) {
 					sourceMap: sourcemap !== false
 				});
 
-				for (const file of result.includedFiles) {
+				for (let file of result.includedFiles) {
+					// `node-sass` always returns unix style paths,
+					// even on windows
+					file = path.normalize(file);
 					this.addWatchFile(file);
 
 					if (!fileToBundles.has(file)) {


### PR DESCRIPTION
Weirdly `node-sass` always returns unix-style paths so we need to normalize those ourselves.

The same workaround can be found in webpack's `sass-loader`: https://github.com/webpack-contrib/sass-loader/blob/38fa37e99aae3af25d15cc51d37bcdc1b23c7227/src/index.js#L59

