### PR TITLE
Sass: Fix full relative paths resolved in wrong directory

### DIFF
--- a/.changeset/tricky-numbers-bow.md
+++ b/.changeset/tricky-numbers-bow.md
@@ -1,0 +1,5 @@
+---
+'wmr': patch
+---
+
+Sass: Fix relative import specifiers in the form of `./foo.scss` being resolved against the wrong directory

--- a/packages/wmr/src/plugins/sass-plugin.js
+++ b/packages/wmr/src/plugins/sass-plugin.js
@@ -65,7 +65,8 @@ export default function sassPlugin({ production, sourcemap, root }) {
 		// do resolution here.
 		let resolved;
 		try {
-			resolved = await pluginResolve(url);
+			const importer = prev !== 'stdin' ? prev : null;
+			resolved = await pluginResolve(url, importer);
 		} catch (err) {
 			done(err);
 			return;

--- a/packages/wmr/test/fixtures.test.js
+++ b/packages/wmr/test/fixtures.test.js
@@ -422,6 +422,16 @@ describe('fixtures', () => {
 				expect(await env.page.$eval('h1', el => getComputedStyle(el).color)).toMatch(/rgb\(255, 0, 0\)/);
 			});
 		});
+
+		it('should resolve js-style relative alias import', async () => {
+			await loadFixture('css-sass-alias-relative', env);
+			instance = await runWmrFast(env.tmp.path);
+			await getOutput(env, instance);
+
+			await withLog(instance.output, async () => {
+				expect(await env.page.$eval('h1', el => getComputedStyle(el).color)).toMatch(/rgb\(255, 0, 0\)/);
+			});
+		});
 	});
 
 	describe('hmr', () => {

--- a/packages/wmr/test/fixtures/css-sass-alias-relative/public/index.html
+++ b/packages/wmr/test/fixtures/css-sass-alias-relative/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="utf-8" />
+		<title>sass</title>
+		<link rel="stylesheet" href="style.scss" />
+	</head>
+	<body>
+		<h1>Sass</h1>
+	</body>
+</html>

--- a/packages/wmr/test/fixtures/css-sass-alias-relative/public/style.scss
+++ b/packages/wmr/test/fixtures/css-sass-alias-relative/public/style.scss
@@ -1,0 +1,1 @@
+@import '../src/foo.scss';

--- a/packages/wmr/test/fixtures/css-sass-alias-relative/src/bar.scss
+++ b/packages/wmr/test/fixtures/css-sass-alias-relative/src/bar.scss
@@ -1,0 +1,1 @@
+$color: red;

--- a/packages/wmr/test/fixtures/css-sass-alias-relative/src/foo.scss
+++ b/packages/wmr/test/fixtures/css-sass-alias-relative/src/foo.scss
@@ -1,0 +1,5 @@
+@import './bar.scss';
+
+h1 {
+	color: $color;
+}

--- a/packages/wmr/test/fixtures/css-sass-alias-relative/wmr.config.mjs
+++ b/packages/wmr/test/fixtures/css-sass-alias-relative/wmr.config.mjs
@@ -1,0 +1,5 @@
+export default {
+	alias: {
+		'src/*': 'src'
+	}
+};


### PR DESCRIPTION
Fix relative import specifiers in the form of `./foo.scss` being resolved against the wrong directory.