### PR TITLE
Add support for logical assignment

### DIFF
--- a/.changeset/cold-cougars-jog.md
+++ b/.changeset/cold-cougars-jog.md
@@ -1,0 +1,19 @@
+---
+'wmr': minor
+---
+
+Add support for logical assignment operators.
+
+```js
+// "Or Or Equals" (or, the Mallet operator :wink:)
+a ||= b;
+a || (a = b);
+
+// "And And Equals"
+a &&= b;
+a && (a = b);
+
+// "QQ Equals"
+a ??= b;
+a ?? (a = b);
+```

--- a/packages/wmr/package.json
+++ b/packages/wmr/package.json
@@ -46,6 +46,7 @@
 		"acorn-import-assertions": "^1.6.0",
 		"acorn-jsx": "^5.3.1",
 		"acorn-jsx-walk": "^2.0.0",
+		"acorn-logical-assignment": "^0.1.4",
 		"acorn-private-methods": "^1.0.0",
 		"acorn-walk": "^8.0.0",
 		"astring": "^1.7.0",

--- a/packages/wmr/src/lib/acorn-default-plugins.js
+++ b/packages/wmr/src/lib/acorn-default-plugins.js
@@ -1,5 +1,6 @@
 import acornClassFields from 'acorn-class-fields';
 import acornPrivateMethods from 'acorn-private-methods';
+import acornLogicalAssignment from 'acorn-logical-assignment';
 
 /**
  * Use a plugin to inject acorn plugins in both development and
@@ -11,7 +12,12 @@ export function acornDefaultPlugins() {
 		name: 'acorn-default-plugins',
 		options(opts) {
 			// @ts-ignore
-			opts.acornInjectPlugins = [acornClassFields, acornPrivateMethods, ...(opts.acornInjectPlugins || [])];
+			opts.acornInjectPlugins = [
+				acornClassFields,
+				acornPrivateMethods,
+				acornLogicalAssignment,
+				...(opts.acornInjectPlugins || [])
+			];
 			return opts;
 		}
 	};

--- a/packages/wmr/test/fixtures.test.js
+++ b/packages/wmr/test/fixtures.test.js
@@ -59,6 +59,12 @@ describe('fixtures', () => {
 		expect(await getOutput(env, instance)).toMatch(`class fields work`);
 	});
 
+	it('should support logical assignments', async () => {
+		await loadFixture('logical-assignment', env);
+		instance = await runWmrFast(env.tmp.path);
+		expect(await getOutput(env, instance)).toMatch(`{"foo":"foo","baz":"qux"}`);
+	});
+
 	it('should not if sub-import is not in export map', async () => {
 		await loadFixture('empty', env);
 		instance = await runWmrFast(env.tmp.path);

--- a/packages/wmr/test/fixtures/logical-assignment/index.html
+++ b/packages/wmr/test/fixtures/logical-assignment/index.html
@@ -1,0 +1,2 @@
+<script src="./index.js" type="module"></script>
+<pre id="out"></pre>

--- a/packages/wmr/test/fixtures/logical-assignment/index.js
+++ b/packages/wmr/test/fixtures/logical-assignment/index.js
@@ -1,0 +1,9 @@
+function example(opts) {
+	opts.foo ??= 'bar';
+	opts.baz ??= 'qux';
+
+	return opts;
+}
+
+const out = document.getElementById('out');
+out.textContent = JSON.stringify(example({ foo: 'foo' }));

--- a/yarn.lock
+++ b/yarn.lock
@@ -1331,6 +1331,11 @@ acorn-jsx@^5.3.1:
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.1.tgz#fc8661e11b7ac1539c47dbfea2e72b3af34d267b"
   integrity sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==
 
+acorn-logical-assignment@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/acorn-logical-assignment/-/acorn-logical-assignment-0.1.4.tgz#1a143a21f022e1707b2bc82f587ae2943f0a570e"
+  integrity sha512-SeqO1iRtc/NeXo4bTkyK0hN0CIoKi/FQMN1NqhTr5UxqEn4p2wKNTZl+xzvU7i2u/k0f66YR7pNPi2ckPwYubg==
+
 acorn-private-class-elements@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/acorn-private-class-elements/-/acorn-private-class-elements-1.0.0.tgz#c5805bf8a46cd065dc9b3513bfebb504c88cd706"


### PR DESCRIPTION
Add support for logical assignment operators.

```js
// "Or Or Equals" (or, the Mallet operator :wink:)
a ||= b;
a || (a = b);

// "And And Equals"
a &&= b;
a && (a = b);

// "QQ Equals"
a ??= b;
a ?? (a = b);
```
