### PR TITLE
Fix wrong regex in process global plugin

### DIFF
--- a/packages/wmr/src/plugins/process-global-plugin.js
+++ b/packages/wmr/src/plugins/process-global-plugin.js
@@ -53,7 +53,7 @@ export default function processGlobalPlugin({ NODE_ENV = 'development', env = {}
 			if (id === `${PREFIX}process.js`) return `export default ${processObj};`;
 		},
 		transform(code, id) {
-			if (!/\.([tj]sx?|mjs)/.test(id)) return;
+			if (!/\.([tj]sx?|mjs)$/.test(id)) return;
 			const orig = code;
 
 			const result = transform(code, {


### PR DESCRIPTION
Currently this doesn't lead to an issue, because we only pass js and style files through our plugin system. It will become an issue once we open it up for more file types in the future though.