### PR TITLE
Add support for passing any file to plugins

### DIFF
--- a/.changeset/curly-panthers-trade.md
+++ b/.changeset/curly-panthers-trade.md
@@ -1,0 +1,5 @@
+---
+'wmr': minor
+---
+
+Add support for passing any file through plugins. This allows plugins to intercept any file.

--- a/.changeset/curly-panthers-trade.md
+++ b/.changeset/curly-panthers-trade.md
@@ -2,4 +2,4 @@
 'wmr': minor
 ---
 
-Add support for passing any file through plugins. This allows plugins to intercept any file.
+Allow plugins to intercept any file that's imported in JavaScript, not just script and stylesheet files.

--- a/packages/wmr/src/wmr-middleware.js
+++ b/packages/wmr/src/wmr-middleware.js
@@ -1,4 +1,4 @@
-import { resolve, dirname, relative, sep, posix, isAbsolute, normalize, basename } from 'path';
+import { resolve, dirname, relative, sep, posix, isAbsolute, normalize, basename, extname } from 'path';
 import { promises as fs, createReadStream } from 'fs';
 import * as kl from 'kolorist';
 import { getWmrClient } from './plugins/wmr/plugin.js';
@@ -284,7 +284,14 @@ export default function wmrMiddleware(options) {
 		} else if (queryParams.has('asset')) {
 			cacheKey += '?asset';
 			transform = TRANSFORMS.asset;
-		} else if (prefix || hasIdPrefix || isModule || /\.([mc]js|[tj]sx?)$/.test(file) || /\.(css|s[ac]ss)$/.test(file)) {
+		} else if (
+			prefix ||
+			hasIdPrefix ||
+			isModule ||
+			/\.([mc]js|[tj]sx?)$/.test(file) ||
+			/\.(css|s[ac]ss)$/.test(file) ||
+			(extname(file) !== '' && extname(file) !== 'html' && !/favicon\.ico$/.test(file))
+		) {
 			transform = TRANSFORMS.js;
 		} else {
 			transform = TRANSFORMS.generic;

--- a/packages/wmr/src/wmr-middleware.js
+++ b/packages/wmr/src/wmr-middleware.js
@@ -535,7 +535,8 @@ export const TRANSFORMS = {
 					});
 
 					// foo.css --> foo.css?module (import of CSS Modules proxy module)
-					if (!hasPrefix && /\.(?![tj]sx?)$/.test(spec)) spec += '?module';
+					const ext = posix.extname(spec);
+					if (!hasPrefix && ext !== '' && !/[tj]sx?$/.test(ext)) spec += '?module';
 
 					// If file resolves outside of root it may be an aliased path.
 					if (spec.startsWith('.')) {

--- a/packages/wmr/test/fixtures.test.js
+++ b/packages/wmr/test/fixtures.test.js
@@ -119,6 +119,14 @@ describe('fixtures', () => {
 		expect(text).toMatch('foo.ts');
 	});
 
+	it('should pass any file', async () => {
+		await loadFixture('markdown', env);
+		instance = await runWmrFast(env.tmp.path);
+		const text = await getOutput(env, instance);
+
+		expect(text).toMatch('it works');
+	});
+
 	describe('empty', () => {
 		it('should print warning for missing index.html file in public dir', async () => {
 			await loadFixture('empty', env);

--- a/packages/wmr/test/fixtures/markdown/foo.md
+++ b/packages/wmr/test/fixtures/markdown/foo.md
@@ -1,0 +1,1 @@
+# It works

--- a/packages/wmr/test/fixtures/markdown/foo.md
+++ b/packages/wmr/test/fixtures/markdown/foo.md
@@ -1,1 +1,0 @@
-# It works

--- a/packages/wmr/test/fixtures/markdown/index.html
+++ b/packages/wmr/test/fixtures/markdown/index.html
@@ -1,0 +1,2 @@
+<pre id="out">it doesn't work</pre>
+<script src="./index.js" type="module"></script>

--- a/packages/wmr/test/fixtures/markdown/index.js
+++ b/packages/wmr/test/fixtures/markdown/index.js
@@ -1,0 +1,3 @@
+import foo from './foo.md';
+
+document.getElementById('out').textContent = foo;

--- a/packages/wmr/test/fixtures/markdown/wmr.config.mjs
+++ b/packages/wmr/test/fixtures/markdown/wmr.config.mjs
@@ -3,7 +3,9 @@ export default {
 		{
 			name: 'markdown-plugin',
 			resolveId(id) {
-				console.log(id);
+				if (/\.md$/.test(id)) {
+					return id;
+				}
 			},
 			load(id) {
 				if (/\.md$/.test(id)) {

--- a/packages/wmr/test/fixtures/markdown/wmr.config.mjs
+++ b/packages/wmr/test/fixtures/markdown/wmr.config.mjs
@@ -1,0 +1,15 @@
+export default {
+	plugins: [
+		{
+			name: 'markdown-plugin',
+			resolveId(id) {
+				console.log(id);
+			},
+			load(id) {
+				if (/\.md$/.test(id)) {
+					return `export default "it works"`;
+				}
+			}
+		}
+	]
+};

--- a/packages/wmr/test/production.test.js
+++ b/packages/wmr/test/production.test.js
@@ -188,6 +188,26 @@ describe('production', () => {
 		});
 	});
 
+	it('should support markdown', async () => {
+		await loadFixture('markdown', env);
+		instance = await runWmr(env.tmp.path, 'build');
+
+		await withLog(instance.output, async () => {
+			const code = await instance.done;
+			expect(code).toEqual(0);
+
+			const { address, stop } = serveStatic(path.join(env.tmp.path, 'dist'));
+			cleanup.push(stop);
+
+			await env.page.goto(address, {
+				waitUntil: ['networkidle0', 'load']
+			});
+
+			const output = await env.page.content();
+			expect(output).toMatch(/it works/);
+		});
+	});
+
 	describe('import assertions', () => {
 		it('should support .json assertion', async () => {
 			await loadFixture('import-assertions', env);


### PR DESCRIPTION
This PR adds support for passing any file forward to plugins. This allows plugins to intercept all kinds of files. The only exception to that are html files for now.

Fixes #721 .