### PR TITLE
Fix regression in process plugin

### DIFF
--- a/.changeset/strange-olives-destroy.md
+++ b/.changeset/strange-olives-destroy.md
@@ -1,0 +1,5 @@
+---
+'wmr': patch
+---
+
+Fix `Cannot read property 'edit' of null` error. This was caused by a wrong alternative to substring matches of `String.prototype.replace`.

--- a/packages/wmr/src/plugins/process-global-plugin.js
+++ b/packages/wmr/src/plugins/process-global-plugin.js
@@ -87,7 +87,7 @@ export default function processGlobalPlugin({ NODE_ENV = 'development', env = {}
 			const reg = /typeof(\s+|\s*\(+\s*)process([^a-zA-Z$_])/g;
 			let match = null;
 			while ((match = reg.exec(code)) !== null) {
-				s.overwrite(match.index, match[0].length, 'typeof$1undefined$2');
+				s.overwrite(match.index, match.index + match[0].length, `typeof${match[1]}undefined${match[2]}`);
 			}
 
 			/** @type {*} */

--- a/packages/wmr/test/fixtures.test.js
+++ b/packages/wmr/test/fixtures.test.js
@@ -712,6 +712,15 @@ describe('fixtures', () => {
 			const output = await getOutput(env, instance);
 			expect(output).toMatch(/it works/i);
 		});
+
+		it('should deal with process evaluation', async () => {
+			await loadFixture('process-object', env);
+			instance = await runWmrFast(env.tmp.path);
+			await withLog(instance.output, async () => {
+				const output = await getOutput(env, instance);
+				expect(output).toMatch(/false/i);
+			});
+		});
 	});
 
 	describe('import.meta.env', () => {

--- a/packages/wmr/test/fixtures/process-object/index.html
+++ b/packages/wmr/test/fixtures/process-object/index.html
@@ -1,0 +1,2 @@
+<pre id="out"></pre>
+<script src="./index.js" type="module"></script>

--- a/packages/wmr/test/fixtures/process-object/index.js
+++ b/packages/wmr/test/fixtures/process-object/index.js
@@ -1,0 +1,2 @@
+const result = typeof process === 'object' && 'development' === 'production';
+document.getElementById('out').textContent = result;


### PR DESCRIPTION
Fix `Cannot read property 'edit' of null` error. This was caused by a wrong alternative to substring matches of `String.prototype.replace`.

This is a regression that was introduced with #715