### PR TITLE
Fix invalid TypeScript ReturnType parameter

### DIFF
--- a/packages/wmr/src/lib/acorn-traverse.js
+++ b/packages/wmr/src/lib/acorn-traverse.js
@@ -49,12 +49,12 @@ cjsDefault(jsxWalk).extend(walk.base);
  * @type {(api: { types: typeof types, template: typeof template }) => PluginContext}
  */
 
-/** @type {ReturnType<createContext> | empty} */
+/** @type {ReturnType<typeof createContext> | empty} */
 let codegenContext;
 
 /**
  * @param {Node} node
- * @param {ReturnType<createContext>} [ctx]
+ * @param {ReturnType<typeof createContext>} [ctx]
  */
 export function generate(node, ctx) {
 	codegenContext = ctx;
@@ -219,7 +219,7 @@ template.ast = function (str, expressions) {
 		str = str.reduce((str, q, i) => str + q + (i === expressions.length ? '' : expressions[i]), '');
 	}
 
-	/** @type {ReturnType<createContext>} */
+	/** @type {ReturnType<typeof createContext>} */
 	// @ts-ignore-next
 	const ctx = this.ctx;
 
@@ -237,7 +237,7 @@ class Path {
 	/**
 	 * @param {Node} node
 	 * @param {Node[]} ancestors
-	 * @param {ReturnType<createContext>} [ctx]
+	 * @param {ReturnType<typeof createContext>} ctx
 	 */
 	constructor(node, ancestors, ctx) {
 		if (node && ctx.paths.has(node)) {
@@ -561,14 +561,14 @@ const types = new Proxy(TYPES, {
 	}
 });
 
-/** @type {ReturnType<createContext>} */
+/** @type {ReturnType<typeof createContext>} */
 let visitingCtx;
 
 /**
  * @param {Node} root
  * @param {Record<string, Visitor>} visitors
  * @param {object} state
- * @this {{ ctx: ReturnType<createContext> }}
+ * @this {{ ctx: ReturnType<typeof createContext> }}
  */
 function visit(root, visitors, state) {
 	const { ctx } = this;
@@ -722,7 +722,7 @@ export function transform(
 	const allPlugins = [];
 	resolvePreset({ presets, plugins }, allPlugins);
 
-	/** @type {Record<string, ReturnType<createMetaVisitor>>} */
+	/** @type {Record<string, ReturnType<typeof createMetaVisitor>>} */
 	const visitors = {};
 
 	for (let i = 0; i < allPlugins.length; i++) {

--- a/packages/wmr/src/lib/npm-middleware.js
+++ b/packages/wmr/src/lib/npm-middleware.js
@@ -14,7 +14,7 @@ import { hasDebugFlag } from './output-utils.js';
 
 /**
  * Serve a "proxy module" that uses the WMR runtime to load CSS.
- * @param {ReturnType<normalizeSpecifier>} meta
+ * @param {ReturnType<typeof normalizeSpecifier>} meta
  * @param {import('http').ServerResponse} res
  * @param {boolean} [isModule]
  */

--- a/packages/wmr/src/plugins/npm-plugin/index.js
+++ b/packages/wmr/src/plugins/npm-plugin/index.js
@@ -38,7 +38,7 @@ export default function npmPlugin({ publicPath = '/@npm', prefix = 'npm/', exter
 			if (importer && importer.startsWith(prefix)) importer = importer.substring(prefix.length);
 
 			// let module, path, version;
-			/** @type {ReturnType <normalizeSpecifier>} */
+			/** @type {ReturnType<typeof normalizeSpecifier>} */
 			let meta;
 
 			const importerMeta = importer && !isDiskPath(importer) && normalizeSpecifier(importer);

--- a/packages/wmr/src/serve.js
+++ b/packages/wmr/src/serve.js
@@ -10,7 +10,7 @@ import { formatBootMessage } from './lib/output-utils.js';
 
 /**
  * @typedef CustomServer
- * @type {polka.Polka & { server?: ReturnType<createServer> | import('http2').Http2Server, http2?: boolean } }
+ * @type {polka.Polka & { server?: ReturnType<typeof createServer> | import('http2').Http2Server, http2?: boolean } }
  */
 
 /**

--- a/packages/wmr/src/server.js
+++ b/packages/wmr/src/server.js
@@ -13,7 +13,7 @@ import { hasDebugFlag } from './lib/output-utils.js';
 
 /**
  * @typedef CustomServer
- * @type {polka.Polka & { server?: ReturnType<createServer> | import('http2').Http2Server, ws?: WebSocketServer, http2?: boolean } }
+ * @type {polka.Polka & { server?: ReturnType<typeof createServer> | import('http2').Http2Server, ws?: WebSocketServer, http2?: boolean } }
  */
 
 /**

--- a/packages/wmr/src/wmr-middleware.js
+++ b/packages/wmr/src/wmr-middleware.js
@@ -416,7 +416,7 @@ function resolveFile(file, cwd, alias) {
 
 /**
  * @typedef Context
- * @property {ReturnType<createPluginContainer>} NonRollup
+ * @property {ReturnType<typeof createPluginContainer>} NonRollup
  * @property {string} id rollup-style cwd-relative file identifier
  * @property {string} file absolute file path
  * @property {string} path request path


### PR DESCRIPTION
The type `ReturnType` only works on types, not on values. A function definition is by default a value and not a type, therefore we need to convert it to a type first via `typeof`.

This fixes intellisense for those type and the popup that shows up when you hover it.

// cc @developit