### PR TITLE
[docs] Slide in sidebar when first shown

### DIFF
--- a/docs/public/components/home-page.js
+++ b/docs/public/components/home-page.js
@@ -2,6 +2,7 @@
 import Meta from './meta.js';
 import Jumbotron from './jumbotron.js';
 import { useContent } from '../lib/use-content.js';
+import { SlotContent } from '../lib/slots.js';
 import homeContent from 'markdown:../content/index.md';
 
 /**
@@ -24,6 +25,9 @@ export default function Home() {
 	return (
 		<div>
 			<Meta {...meta} />
+			<SlotContent name="sidebar">
+				<aside class="sidebar hidden" tabIndex={0} />
+			</SlotContent>
 			<div class="main">
 				<Jumbotron />
 				<div class="feature-grid">

--- a/docs/public/styles/index.css
+++ b/docs/public/styles/index.css
@@ -437,6 +437,13 @@ h5:hover .anchor {
 	z-index: 200;
 	outline: none;
 	transition: background 0.3s;
+	animation: sidebar-slide 300ms ease forwards 1 200ms;
+}
+
+@keyframes sidebar-slide {
+	0% {
+		transform: translateX(-100%);
+	}
 }
 
 /** Mobile off-canvas sidebar layout */
@@ -450,6 +457,7 @@ h5:hover .anchor {
 	.sidebar {
 		transform: translateX(-16rem);
 		transition: transform 150ms ease;
+		animation: none;
 		overflow: visible;
 	}
 	.sidebar:focus,

--- a/docs/public/styles/index.css
+++ b/docs/public/styles/index.css
@@ -437,13 +437,10 @@ h5:hover .anchor {
 	z-index: 200;
 	outline: none;
 	transition: background 0.3s;
-	animation: sidebar-slide 500ms ease forwards 1;
 }
-
-@keyframes sidebar-slide {
-	0% {
-		transform: translateX(-100%);
-	}
+.sidebar.hidden {
+	transform: translateX(-100%);
+	pointer-events: none;
 }
 
 /** Mobile off-canvas sidebar layout */

--- a/docs/public/styles/index.css
+++ b/docs/public/styles/index.css
@@ -437,7 +437,7 @@ h5:hover .anchor {
 	z-index: 200;
 	outline: none;
 	transition: background 0.3s;
-	animation: sidebar-slide 300ms ease forwards 1 200ms;
+	animation: sidebar-slide 500ms ease forwards 1;
 }
 
 @keyframes sidebar-slide {

--- a/docs/public/styles/index.css
+++ b/docs/public/styles/index.css
@@ -436,7 +436,7 @@ h5:hover .anchor {
 	overflow: auto;
 	z-index: 200;
 	outline: none;
-	transition: background 0.3s;
+	transition: background 0.3s, transform 0.5s;
 }
 .sidebar.hidden {
 	transform: translateX(-100%);
@@ -482,6 +482,9 @@ h5:hover .anchor {
 		color: #fff;
 		pointer-events: all;
 		transition: transform 150ms ease;
+	}
+	.sidebar.hidden:before {
+		display: none;
 	}
 	.sidebar:focus:before,
 	.sidebar:focus-within:before,


### PR DESCRIPTION
The sidebar comes in before the content when clicking "Get Started". This animation makes that feel a little nicer.

I was slightly worried about what happens on initial page load / reloads directly on `/docs` pages though.