### PR TITLE
Improve error message when prerender() is not exported

### DIFF
--- a/.changeset/clean-crabs-wait.md
+++ b/.changeset/clean-crabs-wait.md
@@ -1,0 +1,5 @@
+---
+"wmr": patch
+---
+
+Improve error message when `prerender()` is not exported

--- a/packages/wmr/src/lib/prerender.js
+++ b/packages/wmr/src/lib/prerender.js
@@ -101,7 +101,7 @@ async function workerCode({ cwd, out, publicPath, customRoutes }) {
 	const m = await $import('file:///' + script);
 	const doPrerender = m.prerender;
 	// const App = m.default || m[Object.keys(m)[0]];
-	
+
 	if (typeof doPrerender !== 'function') {
 		throw Error(`No prerender() function was exported by the first <script src="..."> in your index.html.`);
 	}

--- a/packages/wmr/src/lib/prerender.js
+++ b/packages/wmr/src/lib/prerender.js
@@ -101,6 +101,10 @@ async function workerCode({ cwd, out, publicPath, customRoutes }) {
 	const m = await $import('file:///' + script);
 	const doPrerender = m.prerender;
 	// const App = m.default || m[Object.keys(m)[0]];
+	
+	if (typeof doPrerender !== 'function') {
+		throw Error(`No prerender() function was exported by the first <script src="..."> in your index.html.`);
+	}
 
 	/**
 	 * @param {HeadElement|HeadElement[]|Set<HeadElement>} element

--- a/packages/wmr/test/fixtures/prerender-missing-export/index.html
+++ b/packages/wmr/test/fixtures/prerender-missing-export/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf8" />
+		<title>default title</title>
+	</head>
+	<body>
+		<script src="./index.js" type="module"></script>
+	</body>
+</html>

--- a/packages/wmr/test/fixtures/prerender-missing-export/index.js
+++ b/packages/wmr/test/fixtures/prerender-missing-export/index.js
@@ -1,0 +1,1 @@
+export function foo() {}

--- a/packages/wmr/test/production.test.js
+++ b/packages/wmr/test/production.test.js
@@ -763,6 +763,17 @@ describe('production', () => {
 
 			expect(await fs.access(path.join(env.tmp.path, 'dist', 'non-existent-link', 'index.html'))).toBeUndefined();
 		});
+
+		it('config should throw if no prerender function is exported', async () => {
+			await loadFixture('prerender-missing-export', env);
+			instance = await runWmr(env.tmp.path, 'build', '--prerender');
+			const code = await instance.done;
+
+			await withLog(instance.output, async () => {
+				expect(code).toBe(1);
+				expect(instance.output.join('\n')).toMatch(/No prerender\(\) function/i);
+			});
+		});
 	});
 
 	describe('Code Splitting', () => {


### PR DESCRIPTION
Addresses the other part of #749 (I think).