### PR TITLE
TypeScript: Add support for `override` keyword

### DIFF
--- a/.changeset/grumpy-dingos-admire.md
+++ b/.changeset/grumpy-dingos-admire.md
@@ -1,0 +1,5 @@
+---
+'wmr': minor
+---
+
+TypeScript: Add support for the `override` keyword on class methods

--- a/package.json
+++ b/package.json
@@ -93,6 +93,6 @@
 		"husky": "^4.2.5",
 		"lint-staged": "^10.2.11",
 		"patch-package": "^6.4.7",
-		"prettier": "^2.0.5"
+		"prettier": "^2.3.2"
 	}
 }

--- a/packages/wmr/package.json
+++ b/packages/wmr/package.json
@@ -84,7 +84,7 @@
 		"sirv": "^1.0.6",
 		"sourcemap-codec": "^1.4.8",
 		"stylis": "^4.0.10",
-		"sucrase": "^3.17.0",
+		"sucrase": "^3.20.0",
 		"tar-stream": "^2.1.3",
 		"terser": "^5.7.0",
 		"tmp-promise": "^3.0.2",

--- a/packages/wmr/src/plugins/fast-cjs-plugin.js
+++ b/packages/wmr/src/plugins/fast-cjs-plugin.js
@@ -1,6 +1,7 @@
 const CJS_KEYWORDS = /\b(module\.exports|exports)\b/;
 
-export const ESM_KEYWORDS = /(\bimport\s*(\{.*?\}\s*from|\s[\w$]+\s+from)?\s*['"]|[\s;]export(\s+(default|const|var|let|function|class)[^\w$]|\s*\{))/;
+export const ESM_KEYWORDS =
+	/(\bimport\s*(\{.*?\}\s*from|\s[\w$]+\s+from)?\s*['"]|[\s;]export(\s+(default|const|var|let|function|class)[^\w$]|\s*\{))/;
 
 const HELPER = `function $$cjs_default$$(m,i){for(i in m)if(i!='default')return m;return m.default||m}`;
 

--- a/packages/wmr/src/plugins/wmr/styles/styles-plugin.js
+++ b/packages/wmr/src/plugins/wmr/styles/styles-plugin.js
@@ -7,7 +7,8 @@ import { matchAlias } from '../../../lib/aliasing.js';
 import { modularizeCss } from './css-modules.js';
 
 // invalid object keys
-const RESERVED_WORDS = /^(abstract|async|boolean|break|byte|case|catch|char|class|const|continue|debugger|default|delete|do|double|else|enum|export|extends|false|final|finally|float|for|function|goto|if|implements|import|in|instanceof|int|interface|let|long|native|new|null|package|private|protected|public|return|short|static|super|switch|synchronized|this|throw|throws|transient|true|try|typeof|var|void|volatile|while|with|yield)$/;
+const RESERVED_WORDS =
+	/^(abstract|async|boolean|break|byte|case|catch|char|class|const|continue|debugger|default|delete|do|double|else|enum|export|extends|false|final|finally|float|for|function|goto|if|implements|import|in|instanceof|int|interface|let|long|native|new|null|package|private|protected|public|return|short|static|super|switch|synchronized|this|throw|throws|transient|true|try|typeof|var|void|volatile|while|with|yield)$/;
 
 /**
  * Implements hot-reloading for stylesheets imported by JS.

--- a/packages/wmr/test/fixtures.test.js
+++ b/packages/wmr/test/fixtures.test.js
@@ -1042,4 +1042,13 @@ describe('fixtures', () => {
 			expect(warns[0].message.trim()).toEqual(warning.trim());
 		});
 	});
+
+	describe('TypeScript', () => {
+		it('should support override keyword', async () => {
+			await loadFixture('typescript-override', env);
+			instance = await runWmrFast(env.tmp.path);
+			await env.page.goto(await instance.address, { waitUntil: 'networkidle0' });
+			expect(await env.page.content()).toMatch(/it works/);
+		});
+	});
 });

--- a/packages/wmr/test/fixtures/typescript-override/index.html
+++ b/packages/wmr/test/fixtures/typescript-override/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf8" />
+		<title>TS</title>
+	</head>
+	<body>
+		<h1>it doesn't work</h1>
+		<script src="/index.ts" type="module"></script>
+	</body>
+</html>

--- a/packages/wmr/test/fixtures/typescript-override/index.ts
+++ b/packages/wmr/test/fixtures/typescript-override/index.ts
@@ -1,0 +1,11 @@
+class A {
+	hi() {}
+}
+
+class B extends A {
+	override hi() {
+		return 'it works';
+	}
+}
+
+document.querySelector('h1').textContent = new B().hi();

--- a/yarn.lock
+++ b/yarn.lock
@@ -7499,10 +7499,10 @@ prettier@^1.18.2, prettier@^1.19.1:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
   integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
 
-prettier@^2.0.5:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
-  integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
+prettier@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.2.tgz#ef280a05ec253712e486233db5c6f23441e7342d"
+  integrity sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==
 
 pretty-format@^26.0.0, pretty-format@^26.6.2:
   version "26.6.2"
@@ -8765,10 +8765,10 @@ stylis@^4.0.10:
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.0.10.tgz#446512d1097197ab3f02fb3c258358c3f7a14240"
   integrity sha512-m3k+dk7QeJw660eIKRRn3xPF6uuvHs/FFzjX3HQ5ove0qYsiygoAhwn5a3IYKaZPo5LrYD0rfVmtv1gNY1uYwg==
 
-sucrase@^3.17.0:
-  version "3.17.1"
-  resolved "https://registry.yarnpkg.com/sucrase/-/sucrase-3.17.1.tgz#b5e35ca7d99db2cc82b3e942934c3746b41ff8e2"
-  integrity sha512-04cNLFAhS4NBG2Z/MTkLY6HdoBsqErv3wCncymFlfFtnpMthurlWYML2RlID4M2BbiJSu1eZdQnE8Lcz4PCe2g==
+sucrase@^3.20.0:
+  version "3.20.0"
+  resolved "https://registry.yarnpkg.com/sucrase/-/sucrase-3.20.0.tgz#a80e865830e27d66a912c938491d474164b06205"
+  integrity sha512-Rsp+BX7DRuCleJvBAHN7gQ3ddk7U0rJev19XlIBF6dAq9vX4Tr5mHk4E7+ig/I7BM3DLYotCmm20lfBElT2XtQ==
   dependencies:
     commander "^4.0.0"
     glob "7.1.6"


### PR DESCRIPTION
This PR adds support for the `override` keyword on class methods. Note that I had to update `prettier` too, because our previous version would error when encountering `override`.

Fixes #714 .