### PR TITLE
Fix unable to intercept wmr middleware

### DIFF
--- a/.changeset/eighty-months-explain.md
+++ b/.changeset/eighty-months-explain.md
@@ -1,0 +1,5 @@
+---
+'wmr': patch
+---
+
+Fix unable to intercept WMR middlewares. Custom middlewares are now the first to be processed, similar to plugins.

--- a/packages/wmr/src/server.js
+++ b/packages/wmr/src/server.js
@@ -104,6 +104,11 @@ export default async function server({ cwd, root, overlayDir, middleware, http2,
 		app.use(compression({ threshold, level: 4 }));
 	}
 
+	// Custom middlewares should always come first, similar to plugins
+	if (middleware) {
+		app.use(...middleware);
+	}
+
 	app.use('/@npm', npmMiddleware({ alias, optimize, cwd }));
 
 	// Chrome devtools often adds `?%20[sm]` to the url
@@ -119,10 +124,6 @@ export default async function server({ cwd, root, overlayDir, middleware, http2,
 
 		next();
 	});
-
-	if (middleware) {
-		app.use(...middleware);
-	}
 
 	if (overlayDir) {
 		app.use(sirv(resolve(root || '', overlayDir), { dev: true }));

--- a/packages/wmr/test/fixtures.test.js
+++ b/packages/wmr/test/fixtures.test.js
@@ -1024,6 +1024,13 @@ describe('fixtures', () => {
 			const text = await env.page.evaluate(`fetch('/test').then(r => r.text())`);
 			expect(text).toEqual('it works');
 		});
+
+		it('should run custom middlewares first', async () => {
+			await loadFixture('middleware-custom', env);
+			instance = await runWmrFast(env.tmp.path);
+			const output = await getOutput(env, instance);
+			expect(output).toMatch(/it works/);
+		});
 	});
 
 	describe('node built-ins', () => {

--- a/packages/wmr/test/fixtures/middleware-custom/bar.js
+++ b/packages/wmr/test/fixtures/middleware-custom/bar.js
@@ -1,0 +1,1 @@
+export const works = 'works';

--- a/packages/wmr/test/fixtures/middleware-custom/foo.js
+++ b/packages/wmr/test/fixtures/middleware-custom/foo.js
@@ -1,0 +1,1 @@
+export const value = "it doesn't work";

--- a/packages/wmr/test/fixtures/middleware-custom/index.html
+++ b/packages/wmr/test/fixtures/middleware-custom/index.html
@@ -1,0 +1,2 @@
+<h1>it doesn't work</h1>
+<script src="./index.js" type="module"></script>

--- a/packages/wmr/test/fixtures/middleware-custom/index.js
+++ b/packages/wmr/test/fixtures/middleware-custom/index.js
@@ -1,0 +1,4 @@
+import { value } from './foo.js';
+import { works } from './bar.js';
+
+document.querySelector('h1').textContent = value + works;

--- a/packages/wmr/test/fixtures/middleware-custom/wmr.config.mjs
+++ b/packages/wmr/test/fixtures/middleware-custom/wmr.config.mjs
@@ -1,0 +1,13 @@
+export default {
+	middleware: [
+		(req, res, next) => {
+			if (req.path === '/foo.js') {
+				res.setHeader('Content-Type', 'application/javascript');
+				res.end(`export const value = "it ";`);
+				return;
+			}
+
+			next();
+		}
+	]
+};


### PR DESCRIPTION
Similar to custom plugins, custom middlewares are now handled before our own internal ones. This allows requests to be intercepted which wasn't possible before.

Fixes #297 .