### PR TITLE
Fix ImportSpecifier's wrongly detected as assert keyword

### DIFF
--- a/.changeset/rare-cars-exercise.md
+++ b/.changeset/rare-cars-exercise.md
@@ -1,0 +1,5 @@
+---
+'wmr': patch
+---
+
+Fix ImportSpecifier wrongly detected as import assert keyword when it starts with `assert*`

--- a/packages/wmr/package.json
+++ b/packages/wmr/package.json
@@ -44,7 +44,7 @@
 		"@rollup/plugin-virtual": "^2.0.3",
 		"@types/jest": "^26.0.4",
 		"acorn-class-fields": "^1.0.0",
-		"acorn-import-assertions": "^1.6.0",
+		"acorn-import-assertions": "^1.7.2",
 		"acorn-jsx": "^5.3.1",
 		"acorn-jsx-walk": "^2.0.0",
 		"acorn-logical-assignment": "^0.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1329,10 +1329,10 @@ acorn-globals@^6.0.0:
     acorn "^7.1.1"
     acorn-walk "^7.1.1"
 
-acorn-import-assertions@^1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/acorn-import-assertions/-/acorn-import-assertions-1.6.0.tgz#1db26ec195e8a2aa34d1ecfb94aa1fa43fc98cd2"
-  integrity sha512-OTkAywQMCkM6IcpQAQZDbn+ux8xfbGVrMel2rz7q9OQYFZNczD9CVqBRNZ80kDDu8T2kx7Wn9/JeT+BK7hcwHw==
+acorn-import-assertions@^1.7.2:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/acorn-import-assertions/-/acorn-import-assertions-1.7.2.tgz#4406083ea36e046e9cdb6cc9abdc0ddb16e7fbe5"
+  integrity sha512-BIhFcmW/EvvT4noRG3yC2LSGhTYbf7rIsUmCgVOP+4HDX12kVwrmk9Un9qfqBD4s9MXASzN075E8PQ4E/sa9Lw==
 
 acorn-jsx-walk@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This was an upstream issue in `acorn-import-assertion` which was patched by @riywo 🎉 

Fixes #769