### PR TITLE
Avoid isIdentifier() crash on null/undefined values

### DIFF
--- a/.changeset/gold-candles-sing.md
+++ b/.changeset/gold-candles-sing.md
@@ -1,0 +1,5 @@
+---
+"wmr": patch
+---
+
+Avoid isIdentifier() crash on null/undefined values

--- a/packages/wmr/src/lib/acorn-traverse.js
+++ b/packages/wmr/src/lib/acorn-traverse.js
@@ -862,7 +862,7 @@ const TYPES = {
 	/** @type {(a:Node,b?:Node)=>boolean} */
 	isIdentifier(a, b) {
 		if (a instanceof Path) a = a.node;
-		if (a.type !== 'Identifier') return false;
+		if (!a || a.type !== 'Identifier') return false;
 		return !b || TYPES.isNodesEquivalent(a, b);
 	},
 	react: {


### PR DESCRIPTION
This should fix the issue @Inviz reported in chat. It might be worth checking how we're ending up passing `null`/`undefined` to `isIdentifier()`, but my guess is that it happens when we're [iterating over the elements of an assignment pattern](https://github.com/preactjs/wmr/blob/1055e92d44f2c4def74127d1653fa3f046c8379a/packages/wmr/src/lib/acorn-traverse.js#L1045) and the pattern has "holes" (which IIRC show up as `elements:[undefined,undefined,b]`):

```
const [, , b] = c;
```

```
500 ./public/components/a/index.js - Cannot read property 'type' of undefined
  at Proxy.isIdentifier (/Users/imac/Sites/medes/web/frontend/node_modules/wmr/wmr.cjs:2:960601)
  at o (/Users/imac/Sites/medes/web/frontend/node_modules/wmr/wmr.cjs:2:962216)
  at o (/Users/imac/Sites/medes/web/frontend/node_modules/wmr/wmr.cjs:2:963656)
  at o (/Users/imac/Sites/medes/web/frontend/node_modules/wmr/wmr.cjs:2:963726)
```