### PR TITLE
Transpile scss files included from html

### DIFF
--- a/.changeset/dull-otters-attack.md
+++ b/.changeset/dull-otters-attack.md
@@ -1,0 +1,5 @@
+---
+'wmr': patch
+---
+
+Transpile scss when it's included from an html file

--- a/packages/wmr/src/plugins/sass-plugin.js
+++ b/packages/wmr/src/plugins/sass-plugin.js
@@ -172,6 +172,7 @@ export default function sassPlugin({ production, sourcemap, root }) {
 			if (bundle) return Array.from(bundle);
 		},
 		async generateBundle(opts, bundle) {
+			if (!production) return;
 			await Promise.all(
 				Object.values(bundle).map(async asset => {
 					if (asset.type !== 'asset' || !/\.s[ac]ss$/.test(asset.fileName)) return;

--- a/packages/wmr/src/plugins/sass-plugin.js
+++ b/packages/wmr/src/plugins/sass-plugin.js
@@ -113,18 +113,6 @@ export default function sassPlugin({ production, sourcemap, root }) {
 			sourceMap: sourcemap !== false
 		});
 
-		for (let file of result.includedFiles) {
-			// `node-sass` always returns unix style paths,
-			// even on windows
-			file = path.normalize(file);
-
-			if (!fileToBundles.has(file)) {
-				fileToBundles.set(file, new Set());
-			}
-			// @ts-ignore
-			fileToBundles.get(file).add(id);
-		}
-
 		return result;
 	}
 
@@ -162,6 +150,19 @@ export default function sassPlugin({ production, sourcemap, root }) {
 
 			try {
 				const result = await transformSass.call(this, id, file, code);
+
+				for (let file of result.includedFiles) {
+					// `node-sass` always returns unix style paths,
+					// even on windows
+					file = path.normalize(file);
+
+					if (!fileToBundles.has(file)) {
+						fileToBundles.set(file, new Set());
+					}
+					this.addWatchFile(file);
+					// @ts-ignore
+					fileToBundles.get(file).add(id);
+				}
 
 				return {
 					code: result.css,


### PR DESCRIPTION
Fixes: https://github.com/preactjs/wmr/issues/771

We were emitting the asset but rollup does not push that through the plugin-pipeline, hence why this is now happening as a post-step when generating the final bundle.