### PR TITLE
Handle JSON string source maps returned from rollup plugins

### DIFF
--- a/.changeset/healthy-shrimps-hope.md
+++ b/.changeset/healthy-shrimps-hope.md
@@ -1,0 +1,5 @@
+---
+'wmr': patch
+---
+
+Handle JSON string source maps returned from rollup plugins

--- a/packages/wmr/src/lib/rollup-plugin-container.js
+++ b/packages/wmr/src/lib/rollup-plugin-container.js
@@ -290,6 +290,18 @@ export function createPluginContainer(plugins, opts = {}) {
 
 				logTransform(`${kl.dim(formatPath(id))} [${plugin.name}]`);
 				if (typeof result === 'object') {
+					if (typeof result.map === 'string') {
+						try {
+							result.map = JSON.parse(result.map);
+						} catch {
+							if (hasDebugFlag()) {
+								logTransform(kl.yellow(`Invalid source map JSON returned by plugin `) + kl.magenta(plugin.name));
+							}
+
+							result.map = undefined;
+						}
+					}
+
 					if (result.map) {
 						// Normalize source map sources URLs for the browser
 						result.map.sources = result.map.sources.map(s => {


### PR DESCRIPTION
Some rollup plugins (such as [rollup-plugin-esbuild](https://www.npmjs.com/package/rollup-plugin-esbuild)) return the source map as a string instead of an object; this string needs to be parsed before we can normalize the source URLs (because right now it throws a "cannot read property 'map' of undefined").