### PR TITLE
Fix Service Worker plugin

### DIFF
--- a/.changeset/fuzzy-files-fail.md
+++ b/.changeset/fuzzy-files-fail.md
@@ -1,0 +1,5 @@
+---
+"@wmrjs/service-worker": patch
+---
+
+Fix Service Worker plugin for WMR 3.5+

--- a/packages/sw-plugin/src/index.js
+++ b/packages/sw-plugin/src/index.js
@@ -18,6 +18,7 @@ export default function swPlugin(options) {
 	}
 
 	const wmrProxyPlugin = {
+		name: 'sw-wmr-proxy-plugin',
 		resolveId(id) {
 			const normalizedId = id[1] + id[2] === ':\\' ? pathToPosix(id.slice(2)) : id;
 			if (id.startsWith('/@npm/')) return id;
@@ -66,7 +67,7 @@ export default function swPlugin(options) {
 			}
 
 			// In development, we bundle to IIFE via Rollup, but use WMR's HTTP server to transpile dependencies:
-			id = path.resolve(options.cwd, id.slice(4));
+			id = path.resolve(options.root, id.slice(4));
 
 			try {
 				var { rollup } = await import('rollup'); // eslint-disable-line no-var
@@ -86,7 +87,7 @@ export default function swPlugin(options) {
 			const fileId = this.emitFile({
 				type: 'asset',
 				name: '_' + id,
-				fileName: '_sw.js',
+				fileName: '_sw.js?asset',  // hack: ensure the dev middleware responds with the raw asset
 				source: output[0].code
 			});
 


### PR DESCRIPTION
This fixes #794. There were two bugs:
1. the child rollup build was looking for `${options.cwd}/${id}`, which means it wasn't respecting `public/`.
2. The plugin was relying on `writeCacheFile()` actually writing to disk - writing into `WRITE_CACHE` doesn't seem to allow intercepting `.js` requests, so the request for the generated `_sw.js` asset (not module) was being handled by the `js` handler. This just appends `?asset` to the generated URL in development (not in prod.