### PR TITLE
fix: Unregister preact-cli's service worker if active

### DIFF
--- a/.changeset/fuzzy-masks-allow.md
+++ b/.changeset/fuzzy-masks-allow.md
@@ -1,0 +1,5 @@
+---
+'wmr': patch
+---
+
+If Preact-CLI's debug service worker is detected, WMR will unregister it to avoid repeated 404 errors.

--- a/packages/wmr/src/plugins/wmr/client.js
+++ b/packages/wmr/src/plugins/wmr/client.js
@@ -412,3 +412,18 @@ function createErrorOverlay(data) {
 	document.body.appendChild(iframe);
 	return iframe;
 }
+
+/**
+ * Removes the debug SW installed by Preact-CLI if it is active.
+ * Overlap between WMR and Preact-CLI users shows this is a semi-common
+ * and recurring issue.
+ */
+if ('serviceWorker' in navigator) {
+	navigator.serviceWorker.getRegistrations().then(registrations => {
+		for (const registration of registrations) {
+			if (registration.active?.scriptURL.endsWith('/sw-debug.js')) {
+				registration.unregister();
+			}
+		}
+	});
+}


### PR DESCRIPTION
Related to #800 

It's come up a few times now in our tracker as well as the Slack that Preact-CLI's debug service worker will cause issues if still active when using WMR. As there's going to be a fair bit of overlap between Preact-CLI and WMR's users, I think this is a common enough situation to justify handling. Even for those that recognize this issue and know how to handle it, this should save opening the dev tools and unregistering manually.

Hopefully this approach isn't too naive, though I'm not sure if there's any better way to target it.

[Preact-CLI also uses `sw.js` and `sw-esm.js`](https://github.com/preactjs/preact-cli/blob/b3b6984a1d022ac3348784061bd8864f66f2d670/packages/cli/lib/lib/entry.js#L10-L29), though no one has brought up issues with them yet as far as I'm aware (they'd only attach when running the prod-like server with CLI's built output) so I'm thinking they're safe to ignore for now. 