### PR TITLE
Fix sass files not renamed to css in prod if directly referenced in html

### DIFF
--- a/.changeset/spicy-cars-study.md
+++ b/.changeset/spicy-cars-study.md
@@ -1,0 +1,5 @@
+---
+'wmr': patch
+---
+
+Fix `.scss` files not being renamed to `.css` on production builds, when they were directly referenced in an HTML file.

--- a/packages/wmr/src/plugins/html-entries-plugin.js
+++ b/packages/wmr/src/plugins/html-entries-plugin.js
@@ -93,9 +93,16 @@ export default function htmlEntriesPlugin({ root, publicPath, sourcemap, mergedA
 				}
 
 				if (tag === 'link' && attrs && attrs.rel && /^stylesheet$/i.test(attrs.rel)) {
+					let assetName = url;
+
+					// Ensure that stylesheets have `.css` as an extension
+					if (/\.s[ac]ss$/.test(assetName)) {
+						assetName = posix.join(posix.dirname(url), posix.basename(url, posix.extname(url)) + '.css');
+					}
+
 					const ref = this.emitFile({
 						type: 'asset',
-						name: url.replace(/^\.\//, '')
+						name: assetName.replace(/^\.\//, '')
 					});
 					all.push(ref);
 					waiting.push(

--- a/packages/wmr/test/production.test.js
+++ b/packages/wmr/test/production.test.js
@@ -315,7 +315,7 @@ describe('production', () => {
 
 			const code = await instance.done;
 			const dir = await fs.readdir(path.join(env.tmp.path, 'dist', 'assets'));
-			expect(dir.some(x => x.endsWith('.scss'))).toBeTruthy();
+			expect(dir.some(x => x.endsWith('.css'))).toBeTruthy();
 			expect(code).toEqual(0);
 			const { address, stop } = serveStatic(path.join(env.tmp.path, 'dist'));
 			cleanup.push(stop);
@@ -332,7 +332,7 @@ describe('production', () => {
 			await instance.done;
 			const dir = await fs.readdir(path.join(env.tmp.path, 'dist'));
 			const [cssFile] = await fs.readdir(path.join(env.tmp.path, 'dist', 'assets'));
-			expect(dir.some(x => x.endsWith('.scss') || x.endsWith('.css'))).toBeFalsy();
+			expect(dir.some(x => x.endsWith('.css'))).toBeFalsy();
 			const hash = cssFile.split('.')[1];
 
 			await updateFile(path.join(env.tmp.path, 'public'), '2.scss', content => content.replace('green', 'red'));
@@ -351,7 +351,7 @@ describe('production', () => {
 			await instance.done;
 			const dir = await fs.readdir(path.join(env.tmp.path, 'dist'));
 			const [cssFile] = await fs.readdir(path.join(env.tmp.path, 'dist', 'assets'));
-			expect(dir.some(x => x.endsWith('.scss') || x.endsWith('.css'))).toBeFalsy();
+			expect(dir.some(x => x.endsWith('.css'))).toBeFalsy();
 			const hash = cssFile.split('.')[1];
 
 			await updateFile(path.join(env.tmp.path, 'public'), '2.scss', content => content.replace('green', 'red'));


### PR DESCRIPTION
This PR fixes an incorrect file extension with production builds, when a `.scss` file was directly referenced in the HTML. It would keep the `.scss` extension and didn't rename the asset to `.css`.