### PR TITLE
Fix building JSX that contains a large object (>5 properties) then JSX in a prop

### DIFF
--- a/.changeset/seven-birds-refuse.md
+++ b/.changeset/seven-birds-refuse.md
@@ -1,0 +1,5 @@
+---
+'wmr': patch
+---
+
+Fix building JSX nodes with object with more than 5 properties and then JSX in ap

--- a/packages/wmr/src/lib/acorn-traverse.js
+++ b/packages/wmr/src/lib/acorn-traverse.js
@@ -82,7 +82,7 @@ let codeGenerator = {
 		} else {
 			// Astring inserts line indents by default
 			// eslint-disable-next-line new-cap
-			astring.baseGenerator.ObjectExpression(node, state);
+			astring.baseGenerator.ObjectExpression.call(this, node, state);
 		}
 	},
 


### PR DESCRIPTION
When building a JSX node with an object with more than 5 properties and a JSX prop, this fixes the following error:
```
TypeError: this[node.value.type] is not a function
```

Creating a new wmr project with the following `public/index.js` currently fails:
```
export function App() {
  return (
    <div
      style={{
        top: 0,
        bottom: 0,
        left: 0,
        right: 0,
        position: "relative",
        display: "block",
      }}
      children={<hr />}
    />
  );
}
```

If the children prop is placed before the style prop, the build succeeds.

This was introduced in https://github.com/preactjs/wmr/commit/2bfb296030be42b3b2ac81e49c98f4cb43033892