### PR TITLE
Fix virtual specifiers starting with `/@` not being supported

### DIFF
--- a/.changeset/cyan-timers-jump.md
+++ b/.changeset/cyan-timers-jump.md
@@ -1,0 +1,5 @@
+---
+'wmr': patch
+---
+
+Add a workaround to support virtual identifiers starting with `/@` to support `rollup-plugin-windicss`.

--- a/packages/wmr/src/plugins/wmr/styles/styles-plugin.js
+++ b/packages/wmr/src/plugins/wmr/styles/styles-plugin.js
@@ -99,16 +99,22 @@ export default function wmrStylesPlugin({ root, hot, production, alias, sourcema
 				}
 			});
 
+			// Preserve asset path to avoid file clashes:
+			//   foo/styles.module.css
+			//   bar/styles.module.css
+			// Both files above should not overwrite each other.
+			// We don't have that problem in production, because
+			// assets are hashed
+			let fileName;
+			if (!production) {
+				fileName = id.startsWith('/@') ? `@id/${id}` : id;
+				fileName += '?asset';
+			}
+
 			const ref = this.emitFile({
 				type: 'asset',
 				name: basename(id).replace(/\.(s[ac]ss|less)$/, '.css'),
-				// Preserve asset path to avoid file clashes:
-				//   foo/styles.module.css
-				//   bar/styles.module.css
-				// Both files above should not overwrite each other.
-				// We don't have that problem in production, because
-				// assets are hashed
-				fileName: !production ? id + '?asset' : undefined,
+				fileName,
 				source
 			});
 

--- a/packages/wmr/test/fixtures.test.js
+++ b/packages/wmr/test/fixtures.test.js
@@ -111,6 +111,18 @@ describe('fixtures', () => {
 		expect(text).toMatch('it works');
 	});
 
+	// Issue #811
+	it('should support virtual ids starting with /@', async () => {
+		await loadFixture('virtual-id-at', env);
+		instance = await runWmrFast(env.tmp.path);
+		await getOutput(env, instance);
+
+		await waitForPass(async () => {
+			const color = await env.page.$eval('h1', el => getComputedStyle(el).color);
+			expect(color).toBe('rgb(255, 0, 0)');
+		});
+	});
+
 	it('should prioritize extensionless import by extension array', async () => {
 		await loadFixture('import-priority', env);
 		instance = await runWmrFast(env.tmp.path);

--- a/packages/wmr/test/fixtures/virtual-id-at/public/index.html
+++ b/packages/wmr/test/fixtures/virtual-id-at/public/index.html
@@ -1,0 +1,2 @@
+<h1>foo</h1>
+<script src="./index.js" type="module"></script>

--- a/packages/wmr/test/fixtures/virtual-id-at/public/index.js
+++ b/packages/wmr/test/fixtures/virtual-id-at/public/index.js
@@ -1,0 +1,1 @@
+import 'virtual:windi.css';

--- a/packages/wmr/test/fixtures/virtual-id-at/wmr.config.mjs
+++ b/packages/wmr/test/fixtures/virtual-id-at/wmr.config.mjs
@@ -1,0 +1,22 @@
+export default function () {
+	const ID = 'virtual:windi.css';
+	const VIRTUAL_ID = '/@windicss/windi.css';
+
+	return {
+		plugins: [
+			{
+				name: 'virtual-id-plugin',
+				resolveId(id) {
+					if (id === ID) {
+						return VIRTUAL_ID;
+					}
+				},
+				load(id) {
+					if (id === VIRTUAL_ID) {
+						return `h1 { color: red; }`;
+					}
+				}
+			}
+		]
+	};
+}

--- a/packages/wmr/test/production.test.js
+++ b/packages/wmr/test/production.test.js
@@ -128,6 +128,24 @@ describe('production', () => {
 		expect(text).toMatch(/it works/);
 	});
 
+	// Issue #811
+	it('should support virtual ids starting with /@', async () => {
+		await loadFixture('virtual-id-at', env);
+		instance = await runWmr(env.tmp.path, 'build');
+		const code = await instance.done;
+		expect(code).toEqual(0);
+
+		const { address, stop } = serveStatic(path.join(env.tmp.path, 'dist'));
+		cleanup.push(stop);
+
+		await env.page.goto(address, {
+			waitUntil: ['networkidle0', 'load']
+		});
+
+		const color = await env.page.$eval('h1', el => getComputedStyle(el).color);
+		expect(color).toBe('rgb(255, 0, 0)');
+	});
+
 	it("should preserve './' for relative specifiers", async () => {
 		await loadFixture('plugin-resolve', env);
 		instance = await runWmr(env.tmp.path, 'build');


### PR DESCRIPTION
There is `rollup-plugin-windicss` which has chosen a virtual identifier that includes a leading slash `/@windicss/windi.css` this is very unfortunate as that character normally means "resolve from the public dir" in our case since we view it through the lens of a webserver.

To workaround that I've added a special case for urls where the leading slash is immediately followed by an at sign `/@`.

Fixes #811