### PR TITLE
Print file that triggered CSS compose warning

### DIFF
--- a/.changeset/metal-ties-run.md
+++ b/.changeset/metal-ties-run.md
@@ -1,0 +1,5 @@
+---
+'wmr': patch
+---
+
+Print file which triggered warning when the `composes` keyword is attempted to be used outside of a CSS-Module file

--- a/packages/wmr/src/plugins/wmr/styles/styles-plugin.js
+++ b/packages/wmr/src/plugins/wmr/styles/styles-plugin.js
@@ -50,7 +50,7 @@ export default function wmrStylesPlugin({ root, hot, production, alias, sourcema
 					const column = lines[lines.length - 1].length;
 					const codeFrame = createCodeFrame(source, line, column);
 
-					const message = `Warning: ICSS ("composes:") is only supported in CSS Modules.`;
+					const message = `Warning: ICSS ("${match[0]}") is only supported in CSS Modules.`;
 					console.warn(`${kl.yellow(message)} ${kl.dim(idRelative)}\n${codeFrame}`);
 				}
 				source = transformCss(source);

--- a/packages/wmr/src/plugins/wmr/styles/styles-plugin.js
+++ b/packages/wmr/src/plugins/wmr/styles/styles-plugin.js
@@ -43,7 +43,9 @@ export default function wmrStylesPlugin({ root, hot, production, alias, sourcema
 				source = await modularizeCss(source, idRelative, mappings, id);
 			} else {
 				if (/(composes:|:global|:local)/.test(source)) {
-					console.warn(`Warning: ICSS ("composes:") is only supported in CSS Modules.`);
+					console.warn(
+						kl.yellow(`Warning: ICSS ("composes:") is only supported in CSS Modules. `) + kl.dim(idRelative)
+					);
 				}
 				source = transformCss(source);
 			}

--- a/packages/wmr/src/plugins/wmr/styles/styles-plugin.js
+++ b/packages/wmr/src/plugins/wmr/styles/styles-plugin.js
@@ -1,6 +1,6 @@
 import { promises as fs } from 'fs';
 import * as kl from 'kolorist';
-import { basename, dirname, relative, resolve, sep, posix } from 'path';
+import { basename, dirname, relative, resolve, sep, posix, extname } from 'path';
 import { transformCssImports } from '../../../lib/transform-css-imports.js';
 import { transformCss } from '../../../lib/transform-css.js';
 import { matchAlias } from '../../../lib/aliasing.js';
@@ -50,8 +50,11 @@ export default function wmrStylesPlugin({ root, hot, production, alias, sourcema
 					const column = lines[lines.length - 1].length;
 					const codeFrame = createCodeFrame(source, line, column);
 
-					const message = `Warning: ICSS ("${match[0]}") is only supported in CSS Modules.`;
-					console.warn(`${kl.yellow(message)} ${kl.dim(idRelative)}\n${codeFrame}`);
+					const originalName = basename(idRelative);
+					const nameHint = basename(idRelative, extname(idRelative)) + '.module' + extname(idRelative);
+
+					const message = `Warning: Keyword "${match[0]}" is only supported in CSS Modules.\nTo resolve this warning rename the file from "${originalName}" to "${nameHint}" to enable CSS Modules.`;
+					console.warn(`${kl.yellow(message)}\n  ${kl.dim(idRelative)}\n${codeFrame}`);
 				}
 				source = transformCss(source);
 			}

--- a/packages/wmr/test/css.test.js
+++ b/packages/wmr/test/css.test.js
@@ -5,6 +5,7 @@ import {
 	setupTest,
 	teardown,
 	updateFile,
+	waitForMessage,
 	waitForPass,
 	withLog
 } from './test-helpers.js';
@@ -89,6 +90,14 @@ describe('CSS', () => {
 			});
 
 			expect(instance.output.join('\n')).toMatch(/Cannot use reserved word/);
+		});
+
+		// eslint-disable-next-line jest/expect-expect
+		it('should warn on composes keyword being used in non CSS module context', async () => {
+			await loadFixture('css-module-compose-warn', env);
+			instance = await runWmrFast(env.tmp.path);
+			await getOutput(env, instance);
+			await waitForMessage(instance.output, /Warning: ICSS/);
 		});
 
 		it('should not overwrite style files', async () => {

--- a/packages/wmr/test/css.test.js
+++ b/packages/wmr/test/css.test.js
@@ -97,7 +97,7 @@ describe('CSS', () => {
 			await loadFixture('css-module-compose-warn', env);
 			instance = await runWmrFast(env.tmp.path);
 			await getOutput(env, instance);
-			await waitForMessage(instance.output, /Warning: ICSS/);
+			await waitForMessage(instance.output, /Warning: Keyword "composes:"/);
 		});
 
 		it('should not overwrite style files', async () => {

--- a/packages/wmr/test/fixtures/css-module-compose-warn/foo.css
+++ b/packages/wmr/test/fixtures/css-module-compose-warn/foo.css
@@ -1,0 +1,7 @@
+.className {
+	color: red;
+}
+
+h1 {
+	composes: className;
+}

--- a/packages/wmr/test/fixtures/css-module-compose-warn/index.html
+++ b/packages/wmr/test/fixtures/css-module-compose-warn/index.html
@@ -1,0 +1,2 @@
+<h1>foo</h1>
+<script src="./index.js" type="module"></script>

--- a/packages/wmr/test/fixtures/css-module-compose-warn/index.js
+++ b/packages/wmr/test/fixtures/css-module-compose-warn/index.js
@@ -1,0 +1,1 @@
+import './foo.css';


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/1062408/131330168-b81fc2aa-4cbb-4ffb-ad65-c7ad17f0c71c.png)

After:
![image](https://user-images.githubusercontent.com/1062408/131331528-1691cc6a-08a1-4ec7-973b-3ce42329f0bb.png)