### PR TITLE
Fix process.env import skewing env inlining offsets

### DIFF
--- a/.changeset/dry-forks-yell.md
+++ b/.changeset/dry-forks-yell.md
@@ -1,0 +1,5 @@
+---
+"wmr": patch
+---
+
+Fix complex `process.env` usage (ex: `let {A}=process.env`, but not `process.env.A`) generating invalid code.

--- a/packages/wmr/src/plugins/process-global-plugin.js
+++ b/packages/wmr/src/plugins/process-global-plugin.js
@@ -69,7 +69,6 @@ export default function processGlobalPlugin({ NODE_ENV = 'development', env = {}
 			});
 
 			code = result.code;
-
 			const s = new MagicString(code);
 
 			// if that wasn't the only way `process.env` was referenced...
@@ -77,10 +76,8 @@ export default function processGlobalPlugin({ NODE_ENV = 'development', env = {}
 				// hack: avoid injecting imports into commonjs modules
 				if (/^\s*(import|export)[\s{]/gm.test(code)) {
 					s.prepend(`import process from '${PREFIX}process.js';\n`);
-					code = `import process from '${PREFIX}process.js';${code}`;
 				} else {
 					s.prepend(`var process=${processObj};\n`);
-					code = `var process=${processObj};${code}`;
 				}
 			}
 

--- a/packages/wmr/src/plugins/process-global-plugin.js
+++ b/packages/wmr/src/plugins/process-global-plugin.js
@@ -79,12 +79,12 @@ export default function processGlobalPlugin({ NODE_ENV = 'development', env = {}
 				} else {
 					s.prepend(`var process=${processObj};\n`);
 				}
-			}
-
-			const reg = /typeof(\s+|\s*\(+\s*)process([^a-zA-Z$_])/g;
-			let match = null;
-			while ((match = reg.exec(code)) !== null) {
-				s.overwrite(match.index, match.index + match[0].length, `typeof${match[1]}undefined${match[2]}`);
+			} else {
+				const reg = /typeof(\s+|\s*\(+\s*)process([^a-zA-Z$_.])/g;
+				let match = null;
+				while ((match = reg.exec(code)) !== null) {
+					s.overwrite(match.index, match.index + match[0].length, `typeof${match[1]}undefined${match[2]}`);
+				}
 			}
 
 			/** @type {*} */

--- a/packages/wmr/test/fixtures.test.js
+++ b/packages/wmr/test/fixtures.test.js
@@ -809,6 +809,35 @@ describe('fixtures', () => {
 				expect(output).toMatch(/false/i);
 			});
 		});
+
+		it('should handle complex / dynamic process.env usage', async () => {
+			await loadFixture('process-complex', env);
+			instance = await runWmrFast(env.tmp.path, {
+				env: {
+					WMR_A: 'wmr-a',
+					WMR_B: 'wmr-b',
+					WMR_C: 'wmr-c'
+				}
+			});
+			await getOutput(env, instance);
+			const result = JSON.parse((await env.page.$eval('#out', node => node.textContent)) || 'undefined');
+			expect(result).toEqual({
+				WMR_A: 'wmr-a',
+				WMR_B: 'wmr-b',
+				NODE_ENV: 'development',
+				keys: ['WMR_A', 'WMR_B', 'WMR_C', 'NODE_ENV'],
+				withFullAccess: {
+					type: 'object',
+					typeofEnv: 'object',
+					typeofWMR_A: 'string'
+				},
+				withoutFullAccess: {
+					type: 'object',
+					typeofEnv: 'object',
+					typeofWMR_A: 'string'
+				}
+			});
+		});
 	});
 
 	describe('import.meta.env', () => {

--- a/packages/wmr/test/fixtures/process-complex/index.html
+++ b/packages/wmr/test/fixtures/process-complex/index.html
@@ -1,0 +1,2 @@
+<pre id="out"></pre>
+<script src="./index.js" type="module"></script>

--- a/packages/wmr/test/fixtures/process-complex/index.js
+++ b/packages/wmr/test/fixtures/process-complex/index.js
@@ -1,0 +1,21 @@
+import withoutFullAccess from './other.js';
+
+const { WMR_A, WMR_B } = process.env;
+const NODE_ENV = process.env.NODE_ENV;
+const keys = Object.keys(process.env);
+const type = typeof process;
+const typeofEnv = typeof process.env;
+const typeofWMR_A = typeof process.env.WMR_A;
+
+document.getElementById('out').textContent = JSON.stringify({
+	WMR_A,
+	WMR_B,
+	NODE_ENV,
+	keys,
+	withFullAccess: {
+		type,
+		typeofEnv,
+		typeofWMR_A
+	},
+	withoutFullAccess
+});

--- a/packages/wmr/test/fixtures/process-complex/other.js
+++ b/packages/wmr/test/fixtures/process-complex/other.js
@@ -1,0 +1,4 @@
+const type = typeof process;
+const typeofEnv = typeof process.env;
+const typeofWMR_A = typeof process.env.WMR_A;
+export default { type, typeofEnv, typeofWMR_A };


### PR DESCRIPTION
This fixes #818. The issue was happening because `code` is passed to MagicString, which assumes all offsets are relative to that string. However, `code` was being modified to prepend an import statement before it gets scanned by the regex, which caused all offsets for `.overwrite()` to be relative to the modified `code` instead of the one that was passed to MagicString.