### PR TITLE
[preact-iso] Router: pass splat matches in params prop instead of as props

### DIFF
--- a/.changeset/quiet-beers-deny.md
+++ b/.changeset/quiet-beers-deny.md
@@ -1,0 +1,5 @@
+---
+"preact-iso": minor
+---
+
+- Bugfix for Router: "splat" parameters (`/:x*` and `/:y*`) should be passed in the `params` prop instead of directly on props

--- a/packages/preact-iso/router.js
+++ b/packages/preact-iso/router.js
@@ -45,7 +45,7 @@ export const exec = (url, route, matches) => {
 		// normal/optional field:
 		if (flag >= '?' || flag === '') continue;
 		// rest (+/*) match:
-		matches[param] = url.slice(i).map(decodeURIComponent).join('/');
+		params[param] = url.slice(i).map(decodeURIComponent).join('/');
 		break;
 	}
 


### PR DESCRIPTION
fix splat (/:x* and /:x+) matches being merged into props instead of params