### PR TITLE
Fix wrong state when browser handles click event

### DIFF
--- a/packages/preact-iso/router.js
+++ b/packages/preact-iso/router.js
@@ -7,7 +7,7 @@ const UPDATE = (state, url) => {
 	if (url && url.type === 'click') {
 		// ignore events the browser takes care of already:
 		if (url.ctrlKey || url.metaKey || url.altKey || url.shiftKey || url.button !== 0) {
-			return;
+			return state;
 		}
 
 		const link = url.target.closest('a[href]');


### PR DESCRIPTION
This fixes an odd behavior (not published yet) introduced in #831.