### PR TITLE
Disable HMR in iife workers

### DIFF
--- a/packages/wmr/src/lib/plugins.js
+++ b/packages/wmr/src/lib/plugins.js
@@ -59,7 +59,8 @@ export function getPlugins(options) {
 	return [
 		acornDefaultPlugins(),
 		...plugins.slice(0, split),
-		features.preact && !production && prefreshPlugin({ sourcemap }),
+		// Skip injecting a client for iife workers
+		!isWorker && features.preact && !production && prefreshPlugin({ sourcemap }),
 		production && htmlEntriesPlugin({ root, publicPath, mergedAssets, sourcemap }),
 		externalUrlsPlugin(),
 		nodeBuiltinsPlugin({ production }),
@@ -92,7 +93,8 @@ export function getPlugins(options) {
 		// Nested workers are not supported at the moment
 		!isWorker && workerPlugin(options),
 		htmPlugin({ production, sourcemap: options.sourcemap }),
-		wmrPlugin({ hot: !production, sourcemap: options.sourcemap }),
+		// Skip injecting a client for iife workers
+		!isWorker && wmrPlugin({ hot: !production, sourcemap: options.sourcemap }),
 		fastCjsPlugin({
 			// Only transpile CommonJS in node_modules and explicit .cjs files:
 			include: /(^npm\/|[/\\]node_modules[/\\]|\.cjs$)/

--- a/packages/wmr/src/plugins/worker-plugin.js
+++ b/packages/wmr/src/plugins/worker-plugin.js
@@ -9,7 +9,7 @@ import * as kl from 'kolorist';
  * @returns {import('rollup').Plugin}
  */
 export function workerPlugin(options) {
-	const plugins = getPlugins({ ...options, runtimeEnv: 'worker' });
+	const plugins = getPlugins({ ...options, isIIFEWorker: true });
 
 	/** @type {Map<string, number>} */
 	const moduleWorkers = new Map();


### PR DESCRIPTION
HMR in transpiled iife (=non-module workers) seems to lead to incorrect AST output when it comes to `$IMPORT_META_HOT$`.

Spent a while debugging this and have not found the actual cause yet, so the changes here serve as a workaround to get them working again.