### PR TITLE
Sort list of output files by size within a group

### DIFF
--- a/.changeset/red-roses-divide.md
+++ b/.changeset/red-roses-divide.md
@@ -1,0 +1,5 @@
+---
+'wmr': patch
+---
+
+Sort list of outputted files by size within a group

--- a/packages/wmr/src/lib/output-utils.js
+++ b/packages/wmr/src/lib/output-utils.js
@@ -11,7 +11,18 @@ export function bundleStats(bundle, outDir) {
 	let total = 0;
 	const assets = bundle.output
 		.filter(asset => !/\.map$/.test(asset.fileName))
-		.sort((a, b) => scoreAsset(b) - scoreAsset(a));
+		.sort((a, b) => {
+			const scoreB = scoreAsset(b);
+			const scoreA = scoreAsset(a);
+
+			if (scoreA === scoreB) {
+				const contentA = a.type === 'asset' ? a.source : a.code;
+				const contentB = b.type === 'asset' ? b.source : b.code;
+				return contentB.length - contentA.length;
+			}
+
+			return scoreB - scoreA;
+		});
 
 	let nonCssAsset = false;
 	const assetsText = assets.reduce((str, output) => {
@@ -55,7 +66,7 @@ function scoreAsset(asset) {
 	}
 	// ...then CSS files
 	else if (/\.css$/.test(asset.fileName)) {
-		return 10;
+		return 9;
 	}
 
 	// ...and everything else after that


### PR DESCRIPTION
Before:

<img width="533" alt="Screenshot 2021-09-05 at 09 53 39" src="https://user-images.githubusercontent.com/1062408/132119689-9cf7b437-f909-4dac-962e-62f0d1b4bead.png">

After:

<img width="540" alt="Screenshot 2021-09-05 at 09 53 26" src="https://user-images.githubusercontent.com/1062408/132119695-94ad68c8-c312-48cf-b909-70dd033672e3.png">
