### PR TITLE
Fix `iife` bundle warning in prod with non-module workers

### DIFF
--- a/.changeset/chatty-dodos-flow.md
+++ b/.changeset/chatty-dodos-flow.md
@@ -1,0 +1,5 @@
+---
+'wmr': patch
+---
+
+Fix `iife`-warning for workers with exports when creating a production build.

--- a/packages/wmr/src/plugins/worker-plugin.js
+++ b/packages/wmr/src/plugins/worker-plugin.js
@@ -69,7 +69,7 @@ export function workerPlugin(options) {
 
 				const res = await bundle.generate({
 					format: 'iife',
-
+					name: path.basename(id, path.extname(id)).replace(/[-.]\w/g, m => m[1].toUpperCase()),
 					sourcemap: options.sourcemap,
 					inlineDynamicImports: true
 				});

--- a/packages/wmr/test/fixtures/worker/foo.worker.js
+++ b/packages/wmr/test/fixtures/worker/foo.worker.js
@@ -3,3 +3,5 @@ import { value } from './dep-b';
 addEventListener('message', () => {
 	postMessage(value);
 });
+
+export const foo = 42;

--- a/packages/wmr/test/worker.test.js
+++ b/packages/wmr/test/worker.test.js
@@ -132,6 +132,8 @@ describe('Workers', () => {
 					expect(h1).toMatch('it works');
 					expect(h2).toMatch('it works');
 				});
+
+				expect(instance.output.join('\n')).not.toMatch(/you may not be able to access the exports of an IIFE bundle/);
 			});
 		});
 


### PR DESCRIPTION
It's harmless and only annoying.