### PR TITLE
Improve CLI output for compilation warnings

### DIFF
--- a/.changeset/shiny-gifts-talk.md
+++ b/.changeset/shiny-gifts-talk.md
@@ -1,0 +1,5 @@
+---
+'wmr': patch
+---
+
+Improve CLI output for compilation warnings

--- a/packages/wmr/src/bundler.js
+++ b/packages/wmr/src/bundler.js
@@ -3,6 +3,7 @@ import * as rollup from 'rollup';
 import terser from './plugins/fast-minify.js';
 import totalist from 'totalist';
 import { getPlugins } from './lib/plugins.js';
+import { onWarn } from './lib/output-utils.js';
 
 /** @param {string} p */
 const pathToPosix = p => p.split(sep).join(posix.sep);
@@ -23,6 +24,7 @@ export async function bundleProd(options) {
 
 	const bundle = await rollup.rollup({
 		input,
+		onwarn: onWarn,
 		perf: !!profile,
 		preserveEntrySignatures: 'allow-extension',
 		manualChunks: npmChunks ? extractNpmChunks : undefined,

--- a/packages/wmr/src/lib/compile-single-module.js
+++ b/packages/wmr/src/lib/compile-single-module.js
@@ -2,6 +2,7 @@ import * as rollup from 'rollup';
 import wmrPlugin from '../plugins/wmr/plugin.js';
 import htmPlugin from '../plugins/htm-plugin.js';
 import sucrasePlugin from '../plugins/sucrase-plugin.js';
+import { onWarn } from './output-utils.js';
 // import localNpmPlugin from './plugins/local-npm-plugin.js';
 
 // disabled for now
@@ -36,6 +37,7 @@ export const compileSingleModule = withCache(
 		// console.log('compiling ' + input);
 		const bundle = await rollup.rollup({
 			input,
+			onwarn: onWarn,
 			treeshake: false,
 			preserveModules: true,
 			// these should theroetically improve performance:

--- a/packages/wmr/src/lib/npm-middleware.js
+++ b/packages/wmr/src/lib/npm-middleware.js
@@ -10,7 +10,7 @@ import aliasPlugin from '../plugins/aliases-plugin.js';
 import { getMimeType } from './mimetypes.js';
 import nodeBuiltinsPlugin from '../plugins/node-builtins-plugin.js';
 import * as kl from 'kolorist';
-import { hasDebugFlag } from './output-utils.js';
+import { hasDebugFlag, onWarn } from './output-utils.js';
 
 /**
  * Serve a "proxy module" that uses the WMR runtime to load CSS.
@@ -130,6 +130,7 @@ async function bundleNpmModule(mod, { source, alias, cwd }) {
 
 	const bundle = await rollup.rollup({
 		input: mod,
+		onwarn: onWarn,
 		// input: '\0entry',
 		cache: npmCache,
 		shimMissingExports: true,

--- a/packages/wmr/src/plugins/worker-plugin.js
+++ b/packages/wmr/src/plugins/worker-plugin.js
@@ -3,6 +3,7 @@ import * as rollup from 'rollup';
 import path from 'path';
 import { getPlugins } from '../lib/plugins.js';
 import * as kl from 'kolorist';
+import { onWarn } from '../lib/output-utils.js';
 
 /**
  * @param {import("wmr").Options} options
@@ -51,6 +52,7 @@ export function workerPlugin(options) {
 				// See: https://bugzilla.mozilla.org/show_bug.cgi?id=1247687
 				const bundle = await rollup.rollup({
 					input: id,
+					onwarn: onWarn,
 					plugins: [
 						{
 							name: 'worker-meta',


### PR DESCRIPTION
Instead of just showing the warning message we'll now show where the warning came from and potentially display a code frame of the code if available.

Before:

<img width="1075" alt="Screenshot 2021-09-05 at 18 36 47" src="https://user-images.githubusercontent.com/1062408/132134455-f3f01aa6-09bf-4f61-ae94-cf9964c32b44.png">

After:

<img width="1101" alt="Screenshot 2021-09-05 at 18 31 59" src="https://user-images.githubusercontent.com/1062408/132134407-3a74a8b3-2477-4c3f-a859-37c2dbf7422a.png">
