### PR TITLE
Fix inline asset paths on windows

### DIFF
--- a/packages/wmr/src/lib/fs-utils.js
+++ b/packages/wmr/src/lib/fs-utils.js
@@ -37,3 +37,13 @@ export function hasCustomPrefix(id) {
 	// Windows disk letters are not prefixes: C:/foo
 	return !/^\0?(?:file|https?):\/\//.test(id) && /^\0?[-\w]{2,}:/.test(id);
 }
+
+/**
+ * Convert a file path to a valid URL path. For example, it replaces windows
+ * path separators with URL path separators.
+ * @param {string} p
+ * @returns {string}
+ */
+export function pathToUrl(p) {
+	return p.replace(/\\/g, '/');
+}

--- a/packages/wmr/src/plugins/url-plugin.js
+++ b/packages/wmr/src/plugins/url-plugin.js
@@ -3,6 +3,7 @@ import { promises as fs } from 'fs';
 import * as kl from 'kolorist';
 import { matchAlias } from '../lib/aliasing.js';
 import { debug } from '../lib/output-utils.js';
+import { pathToUrl } from '../lib/fs-utils.js';
 
 export const IMPLICIT_URL = /\.(?:png|jpe?g|gif|webp|svg|mp4|webm|ogg|mp3|wav|flac|aac|woff2?|eot|ttf|otf)$/i;
 
@@ -34,7 +35,7 @@ export default function urlPlugin({ inline, root, alias }) {
 			// In dev mode, we turn the import into an inline module that avoids a network request:
 			if (inline) {
 				const aliased = matchAlias(alias, resolved.id);
-				const url = (aliased || '/' + relative(root, resolved.id)) + '?asset';
+				const url = pathToUrl(aliased || '/' + relative(root, resolved.id)) + '?asset';
 				log(`${kl.green('inline')} ${kl.dim(url)} <- ${kl.dim(resolved.id)}`);
 				return {
 					id: escapeUrl(`data:text/javascript,export default${JSON.stringify(url)}`),


### PR DESCRIPTION
Convert windows paths to valid URL paths when inlining asset URLs