### PR TITLE
Fix `debug: true` option in config file not being respected

### DIFF
--- a/.changeset/rare-moles-brush.md
+++ b/.changeset/rare-moles-brush.md
@@ -1,0 +1,5 @@
+---
+'wmr': patch
+---
+
+Fix `debug: true` option from config file not being set

--- a/packages/wmr/src/lib/normalize-options.js
+++ b/packages/wmr/src/lib/normalize-options.js
@@ -17,8 +17,6 @@ export async function normalizeOptions(options, mode, configWatchFiles = []) {
 	options.cwd = resolve(options.cwd || '');
 	process.chdir(options.cwd);
 
-	if (options.debug) setDebugCliArg(true);
-
 	options.root = options.cwd;
 
 	options.minify = mode === 'build';
@@ -242,6 +240,8 @@ export async function normalizeOptions(options, mode, configWatchFiles = []) {
 			options.alias[name] = resolve(options.cwd, value);
 		}
 	}
+
+	if (options.debug) setDebugCliArg(true);
 
 	debug('wmr:config')(options);
 


### PR DESCRIPTION
Note: Didn't add a test as our test setup always enables debug by default to make inspection easier.

Fixes #855 .