### PR TITLE
Make process.env test resilient against env ordering

### DIFF
--- a/packages/wmr/test/fixtures.test.js
+++ b/packages/wmr/test/fixtures.test.js
@@ -813,22 +813,25 @@ describe('fixtures', () => {
 				}
 			});
 			await getOutput(env, instance);
-			const result = JSON.parse((await env.page.$eval('#out', node => node.textContent)) || 'undefined');
-			expect(result).toEqual({
-				WMR_A: 'wmr-a',
-				WMR_B: 'wmr-b',
-				NODE_ENV: 'development',
-				keys: ['WMR_A', 'WMR_B', 'WMR_C', 'NODE_ENV'],
-				withFullAccess: {
-					type: 'object',
-					typeofEnv: 'object',
-					typeofWMR_A: 'string'
-				},
-				withoutFullAccess: {
-					type: 'object',
-					typeofEnv: 'object',
-					typeofWMR_A: 'string'
-				}
+
+			await withLog(instance.output, async () => {
+				const result = JSON.parse((await env.page.$eval('#out', node => node.textContent)) || 'undefined');
+				expect(result).toEqual({
+					WMR_A: 'wmr-a',
+					WMR_B: 'wmr-b',
+					NODE_ENV: 'development',
+					keys: ['NODE_ENV', 'WMR_A', 'WMR_B', 'WMR_C'],
+					withFullAccess: {
+						type: 'object',
+						typeofEnv: 'object',
+						typeofWMR_A: 'string'
+					},
+					withoutFullAccess: {
+						type: 'object',
+						typeofEnv: 'object',
+						typeofWMR_A: 'string'
+					}
+				});
 			});
 		});
 	});

--- a/packages/wmr/test/fixtures/process-complex/index.js
+++ b/packages/wmr/test/fixtures/process-complex/index.js
@@ -2,7 +2,7 @@ import withoutFullAccess from './other.js';
 
 const { WMR_A, WMR_B } = process.env;
 const NODE_ENV = process.env.NODE_ENV;
-const keys = Object.keys(process.env);
+const keys = Object.keys(process.env).sort();
 const type = typeof process;
 const typeofEnv = typeof process.env;
 const typeofWMR_A = typeof process.env.WMR_A;


### PR DESCRIPTION
On one of my machines the ordering seems to be different