### PR TITLE
Fix error when using static class fields

### DIFF
--- a/.changeset/rude-goats-hammer.md
+++ b/.changeset/rude-goats-hammer.md
@@ -1,0 +1,5 @@
+---
+'wmr': patch
+---
+
+Fix compilation error when using `static` class fields

--- a/packages/wmr/package.json
+++ b/packages/wmr/package.json
@@ -50,6 +50,7 @@
 		"acorn-jsx-walk": "^2.0.0",
 		"acorn-logical-assignment": "^0.1.4",
 		"acorn-private-methods": "^1.0.0",
+		"acorn-static-class-features": "^1.0.0",
 		"acorn-walk": "^8.0.0",
 		"astring": "^1.7.0",
 		"async-disk-cache": "^2.1.0",

--- a/packages/wmr/src/lib/acorn-default-plugins.js
+++ b/packages/wmr/src/lib/acorn-default-plugins.js
@@ -1,6 +1,7 @@
 import acornClassFields from 'acorn-class-fields';
 import acornPrivateMethods from 'acorn-private-methods';
 import acornLogicalAssignment from 'acorn-logical-assignment';
+import acornStaticClass from 'acorn-static-class-features';
 
 /**
  * Use a plugin to inject acorn plugins in both development and
@@ -13,6 +14,7 @@ export function acornDefaultPlugins() {
 		options(opts) {
 			// @ts-ignore
 			opts.acornInjectPlugins = [
+				acornStaticClass,
 				acornClassFields,
 				acornPrivateMethods,
 				acornLogicalAssignment,

--- a/packages/wmr/test/fixtures.test.js
+++ b/packages/wmr/test/fixtures.test.js
@@ -54,6 +54,12 @@ describe('fixtures', () => {
 		expect(await getOutput(env, instance)).toMatch(`class fields work`);
 	});
 
+	it('should support static class-fields', async () => {
+		await loadFixture('class-fields-static', env);
+		instance = await runWmrFast(env.tmp.path);
+		expect(await getOutput(env, instance)).toMatch(`class fields work`);
+	});
+
 	it('should support private class-fields', async () => {
 		await loadFixture('class-fields-private', env);
 		instance = await runWmrFast(env.tmp.path);

--- a/packages/wmr/test/fixtures/class-fields-static/index.html
+++ b/packages/wmr/test/fixtures/class-fields-static/index.html
@@ -1,0 +1,2 @@
+<script src="./index.js" type="module"></script>
+<pre id="out"></pre>

--- a/packages/wmr/test/fixtures/class-fields-static/index.js
+++ b/packages/wmr/test/fixtures/class-fields-static/index.js
@@ -1,0 +1,5 @@
+class Foo {
+	static state = 'class fields work';
+}
+
+document.getElementById('out').textContent = Foo.state;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1342,9 +1342,9 @@ acorn-globals@^6.0.0:
     acorn-walk "^7.1.1"
 
 acorn-import-assertions@^1.7.2:
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/acorn-import-assertions/-/acorn-import-assertions-1.7.2.tgz#4406083ea36e046e9cdb6cc9abdc0ddb16e7fbe5"
-  integrity sha512-BIhFcmW/EvvT4noRG3yC2LSGhTYbf7rIsUmCgVOP+4HDX12kVwrmk9Un9qfqBD4s9MXASzN075E8PQ4E/sa9Lw==
+  version "1.7.6"
+  resolved "https://registry.yarnpkg.com/acorn-import-assertions/-/acorn-import-assertions-1.7.6.tgz#580e3ffcae6770eebeec76c3b9723201e9d01f78"
+  integrity sha512-FlVvVFA1TX6l3lp8VjDnYYq7R1nyW6x3svAt4nDgrWQ9SBaSh9CnbwgSUTasgfNfOG5HlM1ehugCvM+hjo56LA==
 
 acorn-jsx-walk@^2.0.0:
   version "2.0.0"
@@ -1370,6 +1370,13 @@ acorn-private-methods@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/acorn-private-methods/-/acorn-private-methods-1.0.0.tgz#b48f4c03a151cc8262f6f5ca8f57f7c5ac245184"
   integrity sha512-Jou2L3nfwfPpFdmmHObI3yUpVPM1bPohTUAZCyVDw5Efyn9LSS6E36neRLCRfIr8QjskAfdxRdABOrvP4c/gwQ==
+  dependencies:
+    acorn-private-class-elements "^1.0.0"
+
+acorn-static-class-features@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/acorn-static-class-features/-/acorn-static-class-features-1.0.0.tgz#ab9d862d5b184007ed509f5a8d031b837694ace2"
+  integrity sha512-XZJECjbmMOKvMHiNzbiPXuXpLAJfN3dAKtfIYbk1eHiWdsutlek+gS7ND4B8yJ3oqvHo1NxfafnezVmq7NXK0A==
   dependencies:
     acorn-private-class-elements "^1.0.0"
 


### PR DESCRIPTION
This code did throw an error due to the static class field:

```js
class Foo {
  static state = 'class fields work';
}
```

This was already reported a while back in #708, but I didn't know that `acorn` needs a special plugin for static fields.

Fixes #708 .