### PR TITLE
Fix false positive in process detection

### DIFF
--- a/.changeset/short-pumas-eat.md
+++ b/.changeset/short-pumas-eat.md
@@ -1,0 +1,5 @@
+---
+'wmr': patch
+---
+
+Resolve a wrongly replaced `process.env` variable when a binding with the name `process` is already in scope. This was encountered when bundling vscode's monaco-editor.

--- a/packages/wmr/src/plugins/process-global-plugin.js
+++ b/packages/wmr/src/plugins/process-global-plugin.js
@@ -7,13 +7,21 @@ import { mergeSourceMaps } from '../lib/sourcemap.js';
  * Plugin to replace `process.env.MY_VAR` or `import.meta.env.MY_VAR` with
  * the actual value.
  * @param {Record<string, string>} env
+ * @param {{falsePositive: boolean}} ctx
  */
-function acornEnvPlugin(env) {
+function acornEnvPlugin(env, ctx) {
 	return () => {
 		return {
 			name: 'transform-env',
 			visitor: {
 				MemberExpression(path) {
+					// False positive: When a binding is in scope with `process` as name.
+					// Example: `import * as process from "./process.js";`
+					if (path.scope.hasBinding('process')) {
+						ctx.falsePositive = true;
+						return;
+					}
+
 					const source = path.getSource();
 					const match = source.match(/^(?:import\.meta|process)\.env\.(.+)/);
 
@@ -59,14 +67,19 @@ export default function processGlobalPlugin({ NODE_ENV = 'development', env = {}
 		transform(code, id) {
 			if (!/\.([tj]sx?|mjs)$/.test(id)) return;
 
+			const ctx = { falsePositive: false };
 			const result = transform(code, {
-				plugins: [acornEnvPlugin({ ...env, NODE_ENV })],
+				plugins: [acornEnvPlugin({ ...env, NODE_ENV }, ctx)],
 				parse: this.parse,
 				filename: id,
 				// Default is to generate sourcemaps, needs an explicit
 				// boolean
 				sourceMaps: !!sourcemap
 			});
+
+			if (ctx.falsePositive) {
+				return;
+			}
 
 			code = result.code;
 			const s = new MagicString(code);

--- a/packages/wmr/test/fixtures.test.js
+++ b/packages/wmr/test/fixtures.test.js
@@ -837,6 +837,15 @@ describe('fixtures', () => {
 				}
 			});
 		});
+
+		it('should not replace false positives', async () => {
+			await loadFixture('process-present', env);
+			instance = await runWmrFast(env.tmp.path);
+			await withLog(instance.output, async () => {
+				const output = await getOutput(env, instance);
+				expect(output).toMatch(/it works/i);
+			});
+		});
 	});
 
 	describe('import.meta.env', () => {

--- a/packages/wmr/test/fixtures/process-present/foo.js
+++ b/packages/wmr/test/fixtures/process-present/foo.js
@@ -1,0 +1,1 @@
+export const env = { value: 'it works' };

--- a/packages/wmr/test/fixtures/process-present/index.html
+++ b/packages/wmr/test/fixtures/process-present/index.html
@@ -1,0 +1,2 @@
+<script src="./index.js" type="module"></script>
+<pre id="out"></pre>

--- a/packages/wmr/test/fixtures/process-present/index.js
+++ b/packages/wmr/test/fixtures/process-present/index.js
@@ -1,0 +1,3 @@
+import * as process from './foo.js';
+
+document.getElementById('out').textContent = process.env.value;


### PR DESCRIPTION
Resolve a wrongly replaced `process.env` variable when a binding with the name `process` is already in scope. This was encountered when bundling vscode's monaco-editor.