### PR TITLE
Don't flood terminal with Rollup's this is undefined warning

### DIFF
--- a/.changeset/nice-snakes-press.md
+++ b/.changeset/nice-snakes-press.md
@@ -1,0 +1,5 @@
+---
+'wmr': patch
+---
+
+Don't flood terminal with harmless `The 'this' keyword is equivalent to 'undefined' at the top level of an ES module, and has been rewritten.` warnings.

--- a/packages/wmr/src/lib/output-utils.js
+++ b/packages/wmr/src/lib/output-utils.js
@@ -249,6 +249,11 @@ export function onWarn(warning) {
 		return;
 	}
 
+	// Hide `this is undefined` warning coming from libraries in
+	// `node_modules`. It's mostly caused by polyfills and Rollup deals
+	// with that automatically, so let's avoid flooding our user's terminal.
+	if (warning.code === 'THIS_IS_UNDEFINED') return;
+
 	const { message, loc, frame } = warning;
 	let msg = formatWarnMessage(message) + '\n';
 

--- a/packages/wmr/test/fixtures.test.js
+++ b/packages/wmr/test/fixtures.test.js
@@ -72,6 +72,15 @@ describe('fixtures', () => {
 		expect(await getOutput(env, instance)).toMatch(`{"foo":"foo","baz":"qux"}`);
 	});
 
+	it('should hide "this is undefined" warning', async () => {
+		await loadFixture('this-undefined', env);
+
+		instance = await runWmrFast(env.tmp.path);
+		await getOutput(env, instance);
+
+		expect(instance.output.join('\n')).not.toMatch(/The 'this' keyword is/);
+	});
+
 	it('should not if sub-import is not in export map', async () => {
 		await loadFixture('empty', env);
 		instance = await runWmrFast(env.tmp.path);

--- a/packages/wmr/test/fixtures/this-undefined/-node_modules/foo/index.js
+++ b/packages/wmr/test/fixtures/this-undefined/-node_modules/foo/index.js
@@ -1,0 +1,1 @@
+export default this;

--- a/packages/wmr/test/fixtures/this-undefined/-node_modules/foo/package.json
+++ b/packages/wmr/test/fixtures/this-undefined/-node_modules/foo/package.json
@@ -1,0 +1,4 @@
+{
+	"name": "foo",
+	"main": "./index.js"
+}

--- a/packages/wmr/test/fixtures/this-undefined/index.html
+++ b/packages/wmr/test/fixtures/this-undefined/index.html
@@ -1,0 +1,2 @@
+<script src="./index.js" type="module"></script>
+<pre id="out"></pre>

--- a/packages/wmr/test/fixtures/this-undefined/index.js
+++ b/packages/wmr/test/fixtures/this-undefined/index.js
@@ -1,0 +1,2 @@
+import foo from 'foo';
+console.log(foo);

--- a/packages/wmr/test/test-helpers.js
+++ b/packages/wmr/test/test-helpers.js
@@ -88,6 +88,15 @@ export async function loadFixture(name, env) {
 		path.join(__dirname, '..', '..', 'directory-plugin', 'package.json'),
 		path.join(env.tmp.path, 'node_modules', '@wmrjs', 'directory-import', 'package.json')
 	);
+
+	// If there is a `-node_modules` directory, copy that over too
+	const fakeDir = path.join(fixture, '-node_modules');
+	if (await isDirectory(fakeDir)) {
+		const dirs = await fs.readdir(fakeDir);
+		for (const dir of dirs) {
+			await ncp(path.join(fakeDir, dir), path.join(env.tmp.path, 'node_modules', dir));
+		}
+	}
 }
 
 /**


### PR DESCRIPTION
It's harmless and mainly caused by polyfills of libraries in
`node_modules`. Rollup deals with that automatically. Came across this with `monaco-editor` where every file seemingly includes polyfills. This leads to the terminal being spammed constantly.