### PR TITLE
[docs] fix focus management

### DIFF
--- a/docs/public/index.js
+++ b/docs/public/index.js
@@ -18,7 +18,7 @@ export function App() {
 			<LocationProvider>
 				<Header />
 				<main tabIndex={0} id="page">
-					<Router onLoadEnd={loaded}>
+					<Router onRouteChange={loaded}>
 						<Home path="/" />
 						<Docs path="/docs/:slug*" />
 					</Router>


### PR DESCRIPTION
page.focus() needs to be called after all route changes, even if no loading occurred.