### PR TITLE
[preact-iso] Fix Router un-rendering incoming same-component route

### DIFF
--- a/.changeset/rude-moons-grow.md
+++ b/.changeset/rude-moons-grow.md
@@ -1,0 +1,5 @@
+---
+"preact-iso": patch
+---
+
+- Fix `<Router>` accidentally un-rendering incoming routes that happen to resolve to the same component as the outgoing route.

--- a/.changeset/rude-moons-grow.md
+++ b/.changeset/rude-moons-grow.md
@@ -2,4 +2,4 @@
 "preact-iso": patch
 ---
 
-- Fix `<Router>` accidentally un-rendering incoming routes that happen to resolve to the same component as the outgoing route.
+Fix `<Router>` accidentally un-rendering incoming routes that happen to resolve to the same component as the outgoing route.

--- a/packages/preact-iso/router.js
+++ b/packages/preact-iso/router.js
@@ -125,7 +125,7 @@ export function Router(props) {
 		});
 
 		return h(RouteContext.Provider, { value: m }, p || d);
-	}, [rest, params]);
+	}, [url]);
 
 	// Reset previous children - if rendering succeeds synchronously, we shouldn't render the previous children.
 	const p = prev.current;


### PR DESCRIPTION
I'm not 100% sure if this is the right solution, but reverting this line fixes the issue:
https://github.com/preactjs/wmr/pull/835/files#diff-b8c8c162d167c1ad31cb8461c49197c9c5527c58c2cde64d5c082d7359878ffdL123

My thinking is that `url` here is the full `location.path + location.search`, so the worst case is that we're potentially re-rendering routers that are unaffected by a given URL change.