### PR TITLE
(wmr) - fix issue relating to windows module css

### DIFF
--- a/.changeset/young-carrots-relate.md
+++ b/.changeset/young-carrots-relate.md
@@ -1,0 +1,5 @@
+---
+'wmr': patch
+---
+
+Normalize the cacheKey in wmr-midddleware so it always corresponds to the WRITE_CACHE map where we store in native-path format keys

--- a/examples/demo/public/home.module.css
+++ b/examples/demo/public/home.module.css
@@ -1,0 +1,3 @@
+.abc {
+	color: black;
+}

--- a/examples/demo/public/home.module.css
+++ b/examples/demo/public/home.module.css
@@ -1,3 +1,0 @@
-.abc {
-	color: black;
-}

--- a/packages/wmr/src/wmr-middleware.js
+++ b/packages/wmr/src/wmr-middleware.js
@@ -298,6 +298,8 @@ export default function wmrMiddleware(options) {
 
 			// TODO: Vefify prefix mappings in write cache
 			cacheKey = prefix + id;
+			// Normalize the cacheKey so it matches what will be in the WRITE_CACHE, where we store in native paths
+			cacheKey = cacheKey.split(posix.sep).join(sep);
 
 			if (!hasIdPrefix) {
 				id = `./${id}`;


### PR DESCRIPTION
Fixes #871

Format of files in `WRITE_CACHE`

```
{
  'index.tsx',
  'pages\\home\\index.js',
  'home.module.css?asset',
  'home.module.css',
  'pages\\_404.js',
  'header.tsx',
  'pages\\home\\style.module.css?asset',
  'pages\\home\\style.module.css'
}
```

While our `cacheKey` was in posix format, the `cacheKey` only seems to affect assets in this matter