### PR TITLE
(chore) - speed up ci execution by seperating the steps

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.18, 14.x]
+        node-version: [12.18, 14.x, 16.x]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.18, 14.x]
+        node-version: [12.18, 14.x, 16.x]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -96,7 +96,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.18, 14.x]
+        node-version: [12.18, 14.x, 16.x]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.18, 14.x, 16.x]
+        node-version: [12.18, 14.x]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.18, 14.x, 16.x]
+        node-version: [12.18, 14.x]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -96,7 +96,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.18, 14.x, 16.x]
+        node-version: [12.18, 14.x]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
             preact-iso:
               - 'packages/preact-iso/**'
 
-  build:
+  wmr-prod-test:
     needs: changes
     runs-on: ubuntu-latest
     strategy:
@@ -40,18 +40,85 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Get Yarn cache directory
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - name: Use Yarn cache
+        uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
       - name: Install
         if: ${{ needs.changes.outputs.wmr == 'true' || needs.changes.outputs.preact-iso == 'true' }}
-        run: yarn --frozen-lockfile
+        run: yarn --prefer-offline --frozen-lockfile --non-interactive --silent
       - name: Build
         if: ${{ needs.changes.outputs.wmr == 'true' }}
         run: yarn wmr build
+        run: yarn wmr test-prod
+
+  wmr-dev-test:
+    needs: changes
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # Change the condition for ESM Dist Test below when changing this.
+        node-version: [12.18, 14.x]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Get Yarn cache directory
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - name: Use Yarn cache
+        uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Install
+        if: ${{ needs.changes.outputs.wmr == 'true' || needs.changes.outputs.preact-iso == 'true' }}
+        run: yarn --prefer-offline --frozen-lockfile --non-interactive --silent
       - name: Test wmr
         if: ${{ needs.changes.outputs.wmr == 'true' }}
         run: yarn eslint packages/wmr && yarn wmr test
-      - name: Test wmr (production build)
-        if: ${{ needs.changes.outputs.wmr == 'true' }}
-        run: yarn wmr test-prod
+
+  preact-iso-test:
+    needs: changes
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # Change the condition for ESM Dist Test below when changing this.
+        node-version: [12.18, 14.x]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Get Yarn cache directory
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - name: Use Yarn cache
+        uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Install
+        if: ${{ needs.changes.outputs.wmr == 'true' || needs.changes.outputs.preact-iso == 'true' }}
+        run: yarn --prefer-offline --frozen-lockfile --non-interactive --silent
       - name: Test preact-iso
         if: ${{ needs.changes.outputs.preact-iso == 'true' }}
         run: yarn eslint packages/preact-iso && yarn iso test
@@ -69,8 +136,19 @@ jobs:
           node-version: 14.x
       - name: Prepare LHCI
         run: npm install -g @lhci/cli@0.4.x
+      - name: Get Yarn cache directory
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - name: Use Yarn cache
+        uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
       - name: Install
-        run: yarn --frozen-lockfile
+        run: yarn --prefer-offline --frozen-lockfile --non-interactive --silent
       - name: Build
         run: yarn ci
       - name: LHCI

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,6 +57,8 @@ jobs:
       - name: Build
         if: ${{ needs.changes.outputs.wmr == 'true' }}
         run: yarn wmr build
+      - name: Test production
+        if: ${{ needs.changes.outputs.wmr == 'true' }}
         run: yarn wmr test-prod
 
   wmr-dev-test:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # Change the condition for ESM Dist Test below when changing this.
         node-version: [12.18, 14.x]
     steps:
       - name: Checkout
@@ -52,7 +51,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
       - name: Install
-        if: ${{ needs.changes.outputs.wmr == 'true' || needs.changes.outputs.preact-iso == 'true' }}
+        if: ${{ needs.changes.outputs.wmr == 'true' }}
         run: yarn --prefer-offline --frozen-lockfile --non-interactive --silent
       - name: Build
         if: ${{ needs.changes.outputs.wmr == 'true' }}
@@ -66,7 +65,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # Change the condition for ESM Dist Test below when changing this.
         node-version: [12.18, 14.x]
     steps:
       - name: Checkout
@@ -87,7 +85,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
       - name: Install
-        if: ${{ needs.changes.outputs.wmr == 'true' || needs.changes.outputs.preact-iso == 'true' }}
+        if: ${{ needs.changes.outputs.wmr == 'true' }}
         run: yarn --prefer-offline --frozen-lockfile --non-interactive --silent
       - name: Test wmr
         if: ${{ needs.changes.outputs.wmr == 'true' }}
@@ -98,7 +96,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # Change the condition for ESM Dist Test below when changing this.
         node-version: [12.18, 14.x]
     steps:
       - name: Checkout
@@ -119,7 +116,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
       - name: Install
-        if: ${{ needs.changes.outputs.wmr == 'true' || needs.changes.outputs.preact-iso == 'true' }}
+        if: ${{ needs.changes.outputs.preact-iso == 'true' }}
         run: yarn --prefer-offline --frozen-lockfile --non-interactive --silent
       - name: Test preact-iso
         if: ${{ needs.changes.outputs.preact-iso == 'true' }}

--- a/packages/wmr/src/build.js
+++ b/packages/wmr/src/build.js
@@ -37,6 +37,7 @@ export default async function build(options) {
 			if (r._discoveredBy) s += kl.dim(` [from ${r._discoveredBy.url}]`);
 			return s;
 		}, '');
+
 		process.stdout.write(
 			kl.bold(`Prerendered ${routes.length} page${routes.length == 1 ? '' : 's'}:`) + routeMap + '\n'
 		);

--- a/packages/wmr/src/plugins/wmr/styles/css-modules.js
+++ b/packages/wmr/src/plugins/wmr/styles/css-modules.js
@@ -83,6 +83,5 @@ export async function modularizeCss(css, id, mappings = [], idAbsolute) {
 		const mapped = Array.from(value).join(' ');
 		mappings.push(`${q + key + q}:'${mapped}'`);
 	});
-
 	return result;
 }

--- a/packages/wmr/src/plugins/wmr/styles/css-modules.js
+++ b/packages/wmr/src/plugins/wmr/styles/css-modules.js
@@ -83,5 +83,6 @@ export async function modularizeCss(css, id, mappings = [], idAbsolute) {
 		const mapped = Array.from(value).join(' ');
 		mappings.push(`${q + key + q}:'${mapped}'`);
 	});
+
 	return result;
 }


### PR DESCRIPTION
This splits up the tests for preact-iso, wmr-dev and wmr-prod so we have a faster output across more machines.

If we merge this we'll have to tweak the mandatory status checks

CC @marvinhagemeister should we add 16.x to our matrix?