### PR TITLE
[iso] Add async onBeforeRoute() prop hook

### DIFF
--- a/packages/preact-iso/router.js
+++ b/packages/preact-iso/router.js
@@ -110,7 +110,7 @@ export function Router(props) {
 	didSuspend.current = false;
 	// current return value of onBeforeRoute() prop
 	const onBeforeRoute = useRef();
-	
+
 	cur.current = useMemo(() => {
 		// This hack prevents Preact from diffing when we swap `cur` to `prev`:
 		if (this.__v && this.__v.__k) this.__v.__k.reverse();
@@ -118,11 +118,16 @@ export function Router(props) {
 		count.current++;
 
 		prev.current = cur.current;
-		
+
 		let obr = props.onBeforeRoute && props.onBeforeRoute(url);
-		onBeforeRoute.current = obr && obr.then && obr.then(() => {
-			if (onBeforeRoute.current === obr) onBeforeRoute.current = null;
-		});
+		if (obr && obr.then) {
+			obr = obr.then(() => {
+				if (onBeforeRoute.current === obr) {
+					onBeforeRoute.current = null;
+				}
+			});
+		}
+		onBeforeRoute.current = obr;
 
 		let p, d, m;
 		toChildArray(props.children).some(vnode => {


### PR DESCRIPTION
This implements `<Router onBeforeRoute={async url => {}}>`. When onBeforeRoute returns a Promise for a given URL transition, that Promise is thrown from within the incoming route to simulate a Suspense-based paused transition. This means each router maintains its own onBeforeRoute "locking" state.

Here's an example that uses `onBeforeRoute` to fetch metadata before rendering any routes:

```js
import { useCallback, useEffect } from 'preact/hooks';
import { LocationProvider, Router, hydrate } from 'preact-iso';

function App() {
  const [meta, setMeta] = useState({});
  const loadMeta = useCallback(async url => {
    const res = await fetch(`${url}.json`);
    setMeta(await res.json());
  }, []);
  useEffect(() => {
    document.title = meta.title;
  }, [meta.title]);
  return (
    <LocationProvider>
      <Router onBeforeRoute={loadMeta}>
        <Home path="/" meta={meta} />
        <About path="/about" meta={meta} />
      </Router>
    </LocationProvider>
  );
}

hydrate(<App />);
```

Demo:
https://glitch.com/edit/#!/plausible-satin-rat?path=public%2Fapp.js%3A44%3A5