### PR TITLE
Fix/prerender hydration

### DIFF
--- a/.changeset/friendly-lions-joke.md
+++ b/.changeset/friendly-lions-joke.md
@@ -1,0 +1,6 @@
+---
+'preact-iso': patch
+'wmr': patch
+---
+
+Fix lack of hydration when not returning prerender data

--- a/packages/preact-iso/prerender.js
+++ b/packages/preact-iso/prerender.js
@@ -46,7 +46,8 @@ export default async function prerender(vnode, options) {
 	};
 
 	try {
-		const html = await render();
+		let html = await render();
+		html += `<script type="isodata"></script>`;
 		return { html, links };
 	} finally {
 		vnodeHook = null;

--- a/packages/wmr/src/lib/prerender.js
+++ b/packages/wmr/src/lib/prerender.js
@@ -179,10 +179,7 @@ async function workerCode({ cwd, out, publicPath, customRoutes }) {
 			}
 
 			if (result.data && typeof result.data === 'object') {
-				body = body.replace(
-					/<script type="isodata"><\/script>/,
-					`<script type="isodata">${JSON.stringify(result.data)}</script>`
-				);
+				body += `<script type="wmrdata">${JSON.stringify(result.data)}</script>`;
 			} else if (result.data) {
 				console.warn('You passed in prerender-data in a non-object format: ', result.data);
 			}

--- a/packages/wmr/src/lib/prerender.js
+++ b/packages/wmr/src/lib/prerender.js
@@ -179,7 +179,10 @@ async function workerCode({ cwd, out, publicPath, customRoutes }) {
 			}
 
 			if (result.data && typeof result.data === 'object') {
-				body += `<script type="isodata">${JSON.stringify(result.data)}</script>`;
+				body = body.replace(
+					/<script type="isodata"><\/script>/,
+					`<script type="isodata">${JSON.stringify(result.data)}</script>`
+				);
 			} else if (result.data) {
 				console.warn('You passed in prerender-data in a non-object format: ', result.data);
 			}

--- a/packages/wmr/test/fixtures/prerender-data/index.js
+++ b/packages/wmr/test/fixtures/prerender-data/index.js
@@ -1,3 +1,3 @@
 export function prerender() {
-	return { html: '<h1>it works</h1>', links: ['/'], data: { hello: 'world' } };
+	return { html: '<h1>it works</h1><script type="isodata"></script>', links: ['/'], data: { hello: 'world' } };
 }

--- a/packages/wmr/test/fixtures/prerender-data/index.js
+++ b/packages/wmr/test/fixtures/prerender-data/index.js
@@ -1,3 +1,3 @@
 export function prerender() {
-	return { html: '<h1>it works</h1><script type="isodata"></script>', links: ['/'], data: { hello: 'world' } };
+	return { html: '<h1>it works</h1>', links: ['/'], data: { hello: 'world' } };
 }

--- a/packages/wmr/test/production.test.js
+++ b/packages/wmr/test/production.test.js
@@ -795,7 +795,7 @@ describe('production', () => {
 			expect(code).toBe(0);
 
 			const index = await fs.readFile(path.join(env.tmp.path, 'dist', 'index.html'), 'utf8');
-			expect(index).toMatch('<script type="isodata">{"hello":"world"}</script>');
+			expect(index).toMatch('<script type="wmrdata">{"hello":"world"}</script>');
 		});
 
 		it('should support prerendered HTML, title & meta tags', async () => {


### PR DESCRIPTION
Hydration vs rendering is [determined by whether `script[type=isodata]` can be found](https://github.com/preactjs/wmr/blob/3401a9bfa6491d25108ad68688c067a7e17d0de5/packages/preact-iso/hydrate.js#L8-L15), however, #585 limited this to only existing when returning prerender data.

I attempted to pick through the slack as [noted here](https://github.com/preactjs/wmr/issues/592#issuecomment-832852523) , though I'm still not sure I haven't missed something that would indicate this is intentional, so let me know. This just seemed like the simplest solution to bring this up with.

If we don't want `preact-iso` to return `isodata` we'll probably need some other marker to decide whether to hydrate or not? 