### PR TITLE
Fix/jsx whitespace

### DIFF
--- a/.changeset/late-comics-end.md
+++ b/.changeset/late-comics-end.md
@@ -1,0 +1,5 @@
+---
+'wmr': patch
+---
+
+Ensures leading newline in text nodes is not converted to whitespace

--- a/packages/wmr/src/lib/acorn-traverse.js
+++ b/packages/wmr/src/lib/acorn-traverse.js
@@ -890,8 +890,12 @@ const TYPES = {
 							// We can drop the whole matched string if it only contains
 							// whitespace characters, because that means we're at the
 							// beginning or at the end of the JSXText node
-							const replacement = /[^\s]/.test(value) ? ' ' : '';
-							value = value.replace(/\s*\n+\s*/g, replacement);
+							if (/[^\s]/.test(value)) {
+								value = value.replace(/(^\s*\n\s*|\s*\n\s*$)/g, '');
+								value = value.replace(/\s*\n+\s*/g, ' ');
+							} else {
+								value = value.replace(/\s*\n+\s*/g, '');
+							}
 						}
 						children.push(TYPES.stringLiteral(value));
 					}

--- a/packages/wmr/test/acorn-traverse.test.js
+++ b/packages/wmr/test/acorn-traverse.test.js
@@ -1331,6 +1331,7 @@ describe('acorn-traverse', () => {
 					<p>это
 
 						👩‍🚀</p>
+					, foo
 					</p>
 				);
 			`;
@@ -1343,6 +1344,7 @@ describe('acorn-traverse', () => {
 				<p>это
 
 					👩‍🚀</p>
+				, foo
 				</p>\`
 			);"
 		`);
@@ -1350,7 +1352,7 @@ describe('acorn-traverse', () => {
 			// Should remove the whitespaces between the HTM generated syntax
 			expect(doTransformWithCompact(expression)).toMatchInlineSnapshot(`
 			"(
-				html\`<p>hello world <p>это 👩‍🚀</p></p>\`
+				html\`<p>hello world<p>это 👩‍🚀</p>, foo</p>\`
 			);"
 			`);
 		});


### PR DESCRIPTION
Fixes #899

Modifies JSXText creation to strip out leading and trailing whitespace if it contains newlines before then replacing any interior whitespace with a space character.