### PR TITLE
fix: Last, not first, non-external script in HTML should have prerender()

### DIFF
--- a/.changeset/pink-turtles-switch.md
+++ b/.changeset/pink-turtles-switch.md
@@ -1,0 +1,5 @@
+---
+'wmr': patch
+---
+
+First script tag in HTML should be assumed to have prerender(), not last

--- a/packages/wmr/src/lib/prerender.js
+++ b/packages/wmr/src/lib/prerender.js
@@ -76,7 +76,7 @@ async function workerCode({ cwd, out, publicPath, customRoutes }) {
 	const SCRIPT_TAG = /<script(?:\s[^>]*?)?\s+src=(['"]?)([^>]*?)\1(?:\s[^>]*?)?>/g;
 
 	let match;
-	while ((match = SCRIPT_TAG.exec(tpl))) {
+	while ((match = SCRIPT_TAG.exec(tpl)) && !script) {
 		// Ignore external urls
 		if (!match || /^(?:https?|file|data)/.test(match[2])) continue;
 

--- a/packages/wmr/src/lib/prerender.js
+++ b/packages/wmr/src/lib/prerender.js
@@ -70,13 +70,13 @@ async function workerCode({ cwd, out, publicPath, customRoutes }) {
 	// Grab the generated HTML file, which we'll use as a template:
 	const tpl = await fs.readFile(path.resolve(cwd, out, 'index.html'), 'utf-8');
 
-	// The first script in the file that is not external is assumed to have a
+	// The last script in the file that is not external is assumed to have a
 	// `prerender` export
 	let script;
 	const SCRIPT_TAG = /<script(?:\s[^>]*?)?\s+src=(['"]?)([^>]*?)\1(?:\s[^>]*?)?>/g;
 
 	let match;
-	while ((match = SCRIPT_TAG.exec(tpl)) && !script) {
+	while ((match = SCRIPT_TAG.exec(tpl))) {
 		// Ignore external urls
 		if (!match || /^(?:https?|file|data)/.test(match[2])) continue;
 
@@ -103,7 +103,7 @@ async function workerCode({ cwd, out, publicPath, customRoutes }) {
 	// const App = m.default || m[Object.keys(m)[0]];
 
 	if (typeof doPrerender !== 'function') {
-		throw Error(`No prerender() function was exported by the first <script src="..."> in your index.html.`);
+		throw Error(`No prerender() function was exported by the last non-external <script src="..."> in your index.html.`);
 	}
 
 	/**


### PR DESCRIPTION
The first script tag in the file _should_ be assumed to have a `prerender()`, however, due to the loop continuing even after the first non-external script tag is found, it was actually the _last_ script tag that was used and would need to have `prerender()`.

It should be noted that [this behavior has existed for the past 9 months](https://github.com/preactjs/wmr/commit/ba2e29f2d5b3fb1a91301c1bff4f2dfba37fb335), and fixing it could potentially cause someone's setup to break. We could just flip the error message/comments instead?

https://github.com/preactjs/wmr/blob/039f79925ecab2e277d32e1f4f7341d38a222b59/packages/wmr/src/lib/prerender.js#L106