### PR TITLE
(fix) Avoid replacing regex group token when present in html

### DIFF
--- a/.changeset/six-pandas-look.md
+++ b/.changeset/six-pandas-look.md
@@ -1,0 +1,5 @@
+---
+'wmr': patch
+---
+
+When prerendering avoid replacing regex group token \$1 when is present in html contents

--- a/packages/wmr/src/lib/prerender.js
+++ b/packages/wmr/src/lib/prerender.js
@@ -211,10 +211,10 @@ async function workerCode({ cwd, out, publicPath, customRoutes }) {
 			html = html.replace(/(<html(\s[^>]*?)?>)/, `<html lang="${enc(head.lang)}">`);
 		}
 
-		html = html.replace(/(<\/head>)/, headHtml + '$1');
+		html = html.replace(/(<\/head>)/, (_, groupMatched) => headHtml + groupMatched);
 
 		// Inject pre-rendered HTML into the start of <body>:
-		html = html.replace(/(<body(\s[^>]*?)?>)/, '$1' + body);
+		html = html.replace(/(<body(\s[^>]*?)?>)/, (_, groupMatched) => groupMatched + body);
 
 		// Write the generated HTML to disk:
 		await fs.mkdir(path.dirname(outFile), { recursive: true }).catch(Object);

--- a/packages/wmr/test/fixtures/prerender-data/index.js
+++ b/packages/wmr/test/fixtures/prerender-data/index.js
@@ -1,3 +1,3 @@
 export function prerender() {
-	return { html: '<h1>it works</h1>', links: ['/'], data: { hello: 'world' } };
+	return { html: '<h1>it works$1</h1>', links: ['/'], data: { hello: 'world' } };
 }


### PR DESCRIPTION
Fixes #912 

Switch from token based replacement to callback based function to avoid replacement of `$1` form within html and data contents at prerender time.