### PR TITLE
feat: Allow top-level await in dev

### DIFF
--- a/.changeset/strong-rabbits-juggle.md
+++ b/.changeset/strong-rabbits-juggle.md
@@ -1,0 +1,5 @@
+---
+'wmr': patch
+---
+
+Supports top-level await in dev

--- a/packages/wmr/src/lib/acorn-traverse.js
+++ b/packages/wmr/src/lib/acorn-traverse.js
@@ -1182,6 +1182,7 @@ function createContext({ code, out, parse, generatorOpts, filename }) {
 					}
 					return Array.prototype.push.call(this, comment);
 				};
+				opts.allowAwaitOutsideFunction = true;
 				isInitialParse = false;
 			}
 			return parse(code, opts);


### PR DESCRIPTION
Supports TLA in dev. Users would otherwise be me with the following:

> 500 \<source\> - Cannot use keyword 'await' outside an async function (\<source\>)

I should add that TLA works just fine in prod build; parser doesn't throw an error and allows it to pass just fine. This is only an issue in dev.

This of course won't work in all environments, but I think it's probably fair to at least enable the syntax to get past the parser? If a user needs to support an older browser or is running a version of Node that doesn't support it, I think it's fair to leave that up to them to correct.