### PR TITLE
fix: Ensure sourcemap `sourcesContent` exists before trying to consume

### DIFF
--- a/.changeset/lemon-doors-hunt.md
+++ b/.changeset/lemon-doors-hunt.md
@@ -1,0 +1,5 @@
+---
+'wmr': patch
+---
+
+Checks to ensure a sourcemap has sourcesContent before attempting to consume it

--- a/packages/wmr/src/lib/sourcemap.js
+++ b/packages/wmr/src/lib/sourcemap.js
@@ -106,10 +106,12 @@ export function mergeSourceMaps(sourceMaps) {
 			sourceRoot = map.sourceRoot;
 		}
 
-		for (let j = 0; j < map.sources.length; j++) {
-			const source = map.sources[j];
-			if (!sourcesCache.has(source)) {
-				sourcesCache.set(source, { index: sourcesCache.size, content: map.sourcesContent[j] || null });
+		if (map.sourcesContent) {
+			for (let j = 0; j < map.sources.length; j++) {
+				const source = map.sources[j];
+				if (!sourcesCache.has(source)) {
+					sourcesCache.set(source, { index: sourcesCache.size, content: map.sourcesContent[j] || null });
+				}
 			}
 		}
 


### PR DESCRIPTION
Closes #926 

[Per the spec](https://docs.google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-_2gc6fAH0KY0k/edit?pli=1), `sourcesContent` is optional so we need to check for its existence before consuming.