### PR TITLE
Feat proposal enable fetching external resources using native fetch API in Node.js version 18 later

### DIFF
--- a/.changeset/young-guests-tap.md
+++ b/.changeset/young-guests-tap.md
@@ -1,0 +1,5 @@
+---
+'wmr': minor
+---
+
+Add fetching external resources using native fetch API when Node.js version 18 later

--- a/packages/wmr/src/lib/prerender.js
+++ b/packages/wmr/src/lib/prerender.js
@@ -96,17 +96,41 @@ async function workerCode({ cwd, out, publicPath, customRoutes }) {
 	let head = { lang: '', title: '', elements: new Set() };
 	globalThis.wmr = { ssr: { head } };
 
+	async function localFetcher(url) {
+		const text = () => fs.readFile(`${out}/${String(url).replace(/^\//, '')}`, 'utf-8');
+		return { text, json: () => text().then(JSON.parse) };
+	}
+
+	const pattern = /^\//;
 	if (globalThis.fetch === undefined) {
+		// When Node.js version under 17, native fetch API undefined
+		// So it will give a warning when the syntax to retrieve the file and the url is passed
 		// @ts-ignore
 		globalThis.fetch = async url => {
-			const pattern = /^\//;
-			const isLocalFile = pattern.test(String(url));
-			if (isLocalFile) {
-				const text = () => fs.readFile(`${out}/${String(url).replace(/^\//, '')}`, 'utf-8');
-				return { text, json: () => text().then(JSON.parse) };
+			if (pattern.test(String(url))) {
+				return localFetcher(url);
 			}
 
-			console.warn(`fetch is not implemented in Node.js, please upgrade to Node.js 18 or above`);
+			console.warn(`fetch is not defined in Node.js version under 17, please upgrade to Node.js version 18 later`);
+		};
+	} else {
+		// At that time, implement using reassignment to avoid entering an infinite loop.
+		const fetcher = fetch;
+		// @ts-ignore
+		delete globalThis.fetch;
+
+		// When Node.js version 18 later, native fetch API is defined
+		// Override with own implementation if you want to retrieve local files in Node.js 18 later
+		// ref https://github.com/preactjs/wmr/pull/935#discussion_r977168334
+		// @ts-ignore
+		globalThis.fetch = async (url, options) => {
+			if (pattern.test(String(url))) {
+				return localFetcher(url);
+			}
+
+			// When fetching an external resource, it returns the native fetch API
+			// though `fetcher` function is an alias created to avoid infinite loops
+			return fetcher(url, options);
 		};
 	}
 

--- a/packages/wmr/src/lib/prerender.js
+++ b/packages/wmr/src/lib/prerender.js
@@ -96,7 +96,13 @@ async function workerCode({ cwd, out, publicPath, customRoutes }) {
 	let head = { lang: '', title: '', elements: new Set() };
 	globalThis.wmr = { ssr: { head } };
 
-	const _fetch = fetch;
+	let _fetch;
+	const nodeVersion = process.version;
+	const isNodeVersionOver18 = Number(nodeVersion.split('.')[0].slice(1)) >= 18;
+	// if Node.js version is under 18, fetch is undefined
+	if (isNodeVersionOver18) {
+		_fetch = fetch;
+	}
 	// @ts-ignore
 	delete globalThis.fetch;
 	// @ts-ignore
@@ -105,8 +111,6 @@ async function workerCode({ cwd, out, publicPath, customRoutes }) {
 		const pattern = /^https?:\/\/[\w/:%#\\$&\\?\\(\\)~\\.=\\+\\-]+/;
 		const isExternalUrl = pattern.test(String(url));
 		if (isExternalUrl) {
-			const nodeVersion = process.version;
-			const isNodeVersionOver18 = Number(nodeVersion.split('.')[0].slice(1)) >= 18;
 			if (isRequested) {
 				return;
 			}

--- a/packages/wmr/test/fixtures/prerender-external-resource-fetch/index.html
+++ b/packages/wmr/test/fixtures/prerender-external-resource-fetch/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf8" />
+		<title>default title</title>
+	</head>
+	<body>
+		<script src="./index.js" type="module"></script>
+	</body>
+</html>

--- a/packages/wmr/test/fixtures/prerender-external-resource-fetch/index.js
+++ b/packages/wmr/test/fixtures/prerender-external-resource-fetch/index.js
@@ -1,0 +1,4 @@
+export async function prerender() {
+	const html = await fetch('https://preactjs.com').then(res => res.text());
+	return { html, links: ['/'] };
+}

--- a/packages/wmr/test/fixtures/prerender-resource-fetch/index.js
+++ b/packages/wmr/test/fixtures/prerender-resource-fetch/index.js
@@ -1,4 +1,4 @@
 export async function prerender() {
-	const md = await fetch('content.md').then(res => res.text());
+	const md = await fetch('/content.md').then(res => res.text());
 	return { html: md, links: ['/'] };
 }

--- a/packages/wmr/test/production.test.js
+++ b/packages/wmr/test/production.test.js
@@ -909,7 +909,7 @@ describe('production', () => {
 				await withLog(instance.output, async () => {
 					expect(code).toBe(1);
 					expect(instance.output.join('\n')).toMatch(
-						/Error: External links are not supported in your current Node.js version/
+						/fetch is not implemented in Node.js, please upgrade to Node.js 18 or above/
 					);
 				});
 			}

--- a/packages/wmr/test/production.test.js
+++ b/packages/wmr/test/production.test.js
@@ -891,12 +891,12 @@ describe('production', () => {
 		});
 
 		// Whether or not to run the test to fetch external resources depends on whether or not a Node.js version 18 later
-		const isNodeVersionOver18 = Number(process.version.split('.')[0].slice(1)) >= 18;
+		const isNodeVersionUnder18 = Number(process.version.split('.')[0].slice(1)) < 18;
 		// Even if you are using Node.js v18 or higher, you will get the error `globalThis.fetch is undefined` here, so get the version from process.version
 		// if (globalThis.fetch === undefined)
-		if (!isNodeVersionOver18) {
-			it.skip('skip should not support fetching resources from external link prerender when Node.js v18 later', () => {});
-			it('should not support fetching resources from external link prerender when Node.js befor v17', async () => {
+		if (isNodeVersionUnder18) {
+			it.skip('skip should support fetching resources from external links during prerender on Node.js v18 later', () => {});
+			it('should not support fetching resources from external links during prerender on Node.js < v18', async () => {
 				await loadFixture('prerender-external-resource-fetch', env);
 				instance = await runWmr(env.tmp.path, 'build', '--prerender');
 				const code = await instance.done;
@@ -909,8 +909,8 @@ describe('production', () => {
 				});
 			});
 		} else {
-			it.skip('skip should not support fetching resources from external link prerender when Node.js befor v17', () => {});
-			it('should not support fetching resources from external link prerender when Node.js v18 later', async () => {
+			it.skip('skip should not support fetching resources from external links during prerender on Node.js < v18', () => {});
+			it('should support fetching resources from external links during prerender on Node.js v18 later', async () => {
 				await loadFixture('prerender-external-resource-fetch', env);
 				instance = await runWmr(env.tmp.path, 'build', '--prerender');
 				const code = await instance.done;


### PR DESCRIPTION
I've defined globalThis.fetch at https://github.com/preactjs/wmr/pull/934, but currently wmr can't access external resources when use prerender mode.
Therefore, I came up with a plan to make fetch available natively in Node.js 18 and later.


But Node.js 18 is not LTS yet, what do you think?