### PR TITLE
fix: As of Node 16, `fs.rmdir()` throws if path does not exist

### DIFF
--- a/packages/wmr/test/production.test.js
+++ b/packages/wmr/test/production.test.js
@@ -471,7 +471,9 @@ describe('production', () => {
 		it('should serve the demo app', async () => {
 			await loadFixture('../../../../examples/demo', env);
 			for (const d of ['dist', 'node_modules', '.cache']) {
-				await fs.rmdir(path.join(env.tmp.path, d), { recursive: true });
+				try {
+					await fs.rmdir(path.join(env.tmp.path, d), { recursive: true });
+				} catch {}
 			}
 			instance = await runWmr(env.tmp.path, 'build', '--prerender');
 			const code = await instance.done;


### PR DESCRIPTION
https://nodejs.org/api/fs.html#fspromisesrmdirpath-options

Breaks our CI now that we're testing Node v18. Simple catch & swallow should be fine in all likelihood.