### PR TITLE
create-wmr: install eslint and eslint-config-preact as dev dependencies

### DIFF
--- a/.changeset/thick-apes-relax.md
+++ b/.changeset/thick-apes-relax.md
@@ -1,0 +1,5 @@
+---
+'create-wmr': patch
+---
+
+Install eslint and eslint-config-preact as dev dependencies

--- a/packages/create-wmr/src/index.js
+++ b/packages/create-wmr/src/index.js
@@ -63,12 +63,13 @@ sade('create-wmr [dir]', true)
 
 		if (opts.eslint) {
 			spinner.start('installing eslint configuration...');
-			await install(['eslint', 'eslint-config-preact'], { prefer: packageManager, cwd });
+			await install(['eslint', 'eslint-config-preact'], { prefer: packageManager, cwd, dev: true });
 			spinner.succeed('installed eslint.');
 		}
 
 		spinner.stop();
 		if (dir) {
+			// eslint-disable-next-line no-console
 			console.log(
 				`\n${bold('To get started:')}\n${dim('$')} ${cyan('cd ' + relative(origCwd, cwd).replace(/^\.[\\/]/, ''))}`
 			);
@@ -83,11 +84,13 @@ sade('create-wmr [dir]', true)
 			Serve the app in production mode:
 			${dim('$ PORT=8080')} ${cyan(`${packageManager === 'npm' ? 'npm run' : 'yarn'} serve`)}
 		`;
+		// eslint-disable-next-line no-console
 		console.log('\n' + result.trim().replace(/^\t\t\t/gm, '') + '\n');
 		if (!opts.eslint) {
+			// eslint-disable-next-line no-console
 			console.log(
 				`\n${bold('To enable ESLint:')} (optional)\n${dim('$')} ${cyan(
-					`${packageManager === 'npm' ? 'npm i' : 'yarn add'} eslint eslint-config-preact`
+					`${packageManager === 'npm' ? 'npm i' : 'yarn add'} -D eslint eslint-config-preact`
 				)}\n`
 			);
 		}


### PR DESCRIPTION
I noticed while using `create-wmr` that when passing `--eslint`, `eslint` and `eslint-config-preact` ended up in `"dependencies"` instead of `"devDependencies"` in my `package.json`.

### Notes
- I added eslint-disable comments because the commit hook was blocking me from committing the file with the pre-existing console statements in it. I saw disable comments in other packages so I figured that's appropriate.
- I haven't been able to manually validate this. Running `yarn prepare` in the `create-wmr` package directory hangs and uses up a whole lot of my CPU. And I'm unable to directly execute `src/index.js` as it uses ES module syntax. Telling node that it's a module results in `__dirname is not defined` errors, as `__dirname` isn't available in ES modules' scope.