### PR TITLE
fix: Worker detection

### DIFF
--- a/.changeset/moody-shirts-smash.md
+++ b/.changeset/moody-shirts-smash.md
@@ -1,0 +1,5 @@
+---
+'wmr': patch
+---
+
+Corrects worker regex pattern to avoid false positives

--- a/packages/wmr/src/plugins/worker-plugin.js
+++ b/packages/wmr/src/plugins/worker-plugin.js
@@ -85,7 +85,8 @@ export function workerPlugin(options) {
 			}
 			// Check if a worker is referenced anywhere in the file
 			else if (/\.(?:[tj]sx?|mjs|cjs)$/.test(id)) {
-				const WORKER_REG = /new URL\(\s*['"]([\w.-/:~]+)['"],\s*import\.meta\.url\s*\)(,\s*{.*?["']module["'].*?})?/gm;
+				const WORKER_REG =
+					/new URL\(\s*['"]([\w.-/:~]+\.worker[\w.-/:~]+)['"],\s*import\.meta\.url\s*\)(,\s*{.*?["']module["'].*?})?/gm;
 
 				if (WORKER_REG.test(code)) {
 					const s = new MagicString(code, {


### PR DESCRIPTION
Workers must have [`.worker` in their name](https://github.com/preactjs/wmr/blob/ab4b512875ae63273cfbd9c4c5972aadd3218bac/packages/wmr/src/plugins/worker-plugin.js#L23) yet this regex didn't test for it. So `new URL('./foo.js', import.meta.url)` is (incorrectly) treated as a worker.

This behavior is still super sketchy and flawed, as a simple `console.log(new URL('./foo.worker.js', import.meta.url))` will trigger (in prod, in dev the user will just get errors) WMR to emit another file, but this at least reduces the chances of users running into it.