### PR TITLE
fix: typecheck in preact jsx.d.ts due to type change related to signals

### DIFF
--- a/.changeset/moody-islands-buy.md
+++ b/.changeset/moody-islands-buy.md
@@ -1,0 +1,5 @@
+---
+'preact-iso': patch
+---
+
+Changed RoutableProps definition to fix a type error in preact, caused by namespace declaration merging.

--- a/packages/preact-iso/router.d.ts
+++ b/packages/preact-iso/router.d.ts
@@ -25,7 +25,6 @@ export const useRoute: () => {
 
 interface RoutableProps {
 	path?: string;
-	default?: boolean;
 }
 
 export interface RouteProps<Props> extends RoutableProps {


### PR DESCRIPTION
as reported in https://github.com/preactjs/preact/issues/3934 the `default` property in `RoutableProps` breaks typechecks in Preact's `jsx.d.ts` file.
This is caused by the addition of Signals to Preact, after which the property is defined as `boolean | undefined | SignalLike<boolean | undefined>` instead of a plain optional boolean.

The type ends up in preact's types because of [namespace declaration merging](https://github.com/robertmaier/wmr/blob/d4ea12ef12bed03d8bd70b5d7bde390dba63c662/packages/preact-iso/router.d.ts#L36-L41).

@marvinhagemeister suggested to remove the `default` definition in `preact-router` [here](https://github.com/preactjs/preact/issues/3934#issuecomment-1473531147). Which is why I would suggest to also do this in `preact-iso`

An alternative solution would be to remove the type merging overall, but I don't have too much knowledge where the type is used.