### PR TITLE
Introduce throwOnFailure option for prerender

### DIFF
--- a/packages/preact-iso/prerender.d.ts
+++ b/packages/preact-iso/prerender.d.ts
@@ -3,6 +3,7 @@ import { VNode } from 'preact';
 export interface PrerenderOptions {
 	maxDepth?: number;
 	props?: Record<string, unknown>;
+	throwOnFailure?: boolean;
 }
 
 export interface PrerenderResult {

--- a/packages/preact-iso/prerender.js
+++ b/packages/preact-iso/prerender.js
@@ -14,6 +14,7 @@ options.vnode = vnode => {
  * @param {object} [options]
  * @param {number} [options.maxDepth = 10] The maximum number of nested asynchronous operations to wait for before flushing
  * @param {object} [options.props] Additional props to merge into the root JSX element
+ * @param {boolean} [options.throwOnFailure] Controls if an exception should be thrown in case rendering fails
  */
 export default async function prerender(vnode, options) {
 	options = options || {};
@@ -47,6 +48,13 @@ export default async function prerender(vnode, options) {
 
 	try {
 		let html = await render();
+		if (typeof html !== "string") {
+			if (options.throwOnFailure) {
+				throw new Error(`Pre-rendering failed! render() evaluated to: ${html}`);
+			} else {
+				html = "";
+			}
+		}
 		html += `<script type="isodata"></script>`;
 		return { html, links };
 	} finally {


### PR DESCRIPTION
# Problem

Due to some unknown issue with `lazy`, the `prerender` function was not working as intended for my components. I eventually managed to overcome that problem, but I did not know that the problem was happening, in the first place, until I manually looked into the generated HTML and noticed it was wrong. In other words, the `prerender` is failing silently since the error path is not being handled correctly, as I'll explain below.

I looked into the WMR internals and found out that the problem was related to this line:

https://github.com/preactjs/wmr/blob/3c5672ecd2f958c8eaf372d33c084dc69228ae3f/packages/preact-iso/prerender.js#L49

The `render` function was returning `undefined` because my components could not be rendered correctly. Then we go into the next line:

https://github.com/preactjs/wmr/blob/3c5672ecd2f958c8eaf372d33c084dc69228ae3f/packages/preact-iso/prerender.js#L50

Since `html` was `undefined`, the generated HTML would become `undefined<script type="isodata"></script>`, which is obviously incorrect and not what I want.

# Solution

There should be a way of generating an exception in case the components cannot be rendered correctly. For that, this PR introduces the `throwOnFailure` option which controls what happens in case rendering fails. It defaults to a falsy value for preserving `prerender`'s current behavior, but arguably it should be true.